### PR TITLE
Fix area hwloc

### DIFF
--- a/tests/area/test_hwloc.c
+++ b/tests/area/test_hwloc.c
@@ -206,7 +206,7 @@ void test_preferred()
 	       AML_SUCCESS);
 
 	data = (struct aml_area_hwloc_preferred_data *)area->data;
-	assert(data->numanodes[data->num_nodes-1] == NUMANODE);
+	assert(data->numanodes[data->num_nodes - 1] == NUMANODE);
 
 	aml_area_hwloc_preferred_destroy(&area);
 }

--- a/tests/area/test_hwloc.c
+++ b/tests/area/test_hwloc.c
@@ -206,7 +206,7 @@ void test_preferred()
 	       AML_SUCCESS);
 
 	data = (struct aml_area_hwloc_preferred_data *)area->data;
-	assert(data->numanodes[0] == NUMANODE);
+	assert(data->numanodes[data->num_nodes-1] == NUMANODE);
 
 	aml_area_hwloc_preferred_destroy(&area);
 }


### PR DESCRIPTION
Fixed the failing test.
The issue arose when the machine has several numanodes.  
The test was assuming a thread pinned by the last numanode and local area chosing first numanode.  
The area was actually working and chosing the last numanode. The test has been fixed to check that the area choses the last numa node instead.