### PR TITLE
[fix] Async Deadlock and Inconsistant State

### DIFF
--- a/include/aml/utils/queue.h
+++ b/include/aml/utils/queue.h
@@ -79,6 +79,29 @@ void *aml_queue_pop(struct aml_queue *q);
 void *aml_queue_take(struct aml_queue *q, void *element);
 
 /**
+ * Get a pointer to first pointer element in the queue.
+ *
+ * @return NULL if the `q` is NULL or empty.
+ * @return A pointer somewhere in `q->elems` pointing to an element
+ * in the queue.
+ **/
+void **aml_queue_head(struct aml_queue *q);
+
+/**
+ * Get next element after `current` in the queue.
+ *
+ * @param q[in]: The queue where `current` comes from.
+ * @param current[in]: A pointer somewhere in `q->elems` or NULL.
+ * If `current` is NULL, then the queue head is returned.
+ * @return NULL if the `q` is NULL, if `q` is empty, if `current` is
+ * the last pointer element in `q` or if `current` is not a pointer
+ * somewhere in `q->elems` pointing to an element in the
+ * queue.
+ * @return A pointer somewhere in `q->elems` pointing to the element
+ * following `current`.
+ **/
+void **aml_queue_next(struct aml_queue *q, void **current);
+/**
  * @}
  **/
 
@@ -86,4 +109,4 @@ void *aml_queue_take(struct aml_queue *q, void *element);
 }
 #endif
 
-#endif //AML_QUEUE_H
+#endif // AML_QUEUE_H

--- a/include/aml/utils/queue.h
+++ b/include/aml/utils/queue.h
@@ -85,13 +85,13 @@ void *aml_queue_take(struct aml_queue *q, void *element);
  * @return A pointer somewhere in `q->elems` pointing to an element
  * in the queue.
  **/
-void **aml_queue_head(struct aml_queue *q);
+void **aml_queue_head(const struct aml_queue *q);
 
 /**
  * Get next element after `current` in the queue.
  *
- * @param q[in]: The queue where `current` comes from.
- * @param current[in]: A pointer somewhere in `q->elems` or NULL.
+ * @param[in] q: The queue where `current` comes from.
+ * @param[in] current: A pointer somewhere in `q->elems` or NULL.
  * If `current` is NULL, then the queue head is returned.
  * @return NULL if the `q` is NULL, if `q` is empty, if `current` is
  * the last pointer element in `q` or if `current` is not a pointer
@@ -100,7 +100,7 @@ void **aml_queue_head(struct aml_queue *q);
  * @return A pointer somewhere in `q->elems` pointing to the element
  * following `current`.
  **/
-void **aml_queue_next(struct aml_queue *q, void **current);
+void **aml_queue_next(const struct aml_queue *q, const void **current);
 /**
  * @}
  **/

--- a/src/utils/queue.c
+++ b/src/utils/queue.c
@@ -37,25 +37,26 @@ void aml_queue_destroy(struct aml_queue *q)
 	free(q);
 }
 
-void **aml_queue_head(struct aml_queue *q)
+void **aml_queue_head(const struct aml_queue *q)
 {
 	if (q->max == 0 || aml_queue_len(q) == 0)
 		return NULL;
 	return &q->elems[q->head];
 }
 
-void **aml_queue_next(struct aml_queue *q, void **current)
+void **aml_queue_next(const struct aml_queue *q, const void **current)
 {
+	const void **elems = (const void **)q->elems;
 	if (q == NULL || q->tail == q->head)
 		return NULL;
 	// Out of bounds return null
-	if (current < q->elems || current >= q->elems + q->max)
+	if (current < elems || current >= elems + q->max)
 		return NULL;
 	// Empty Queue
 	if (q->tail == q->head)
 		return NULL;
 	// End of queue
-	if (current == q->elems + q->tail - 1)
+	if (current == elems + q->tail - 1)
 		return NULL;
 	// special value query head
 	if (current == NULL)
@@ -63,18 +64,17 @@ void **aml_queue_next(struct aml_queue *q, void **current)
 	// All element are contiguous.
 	if (q->tail > q->head) {
 		// Out of bounds
-		if (current < q->elems + q->head ||
-		    current >= q->elems + q->tail)
+		if (current < elems + q->head || current >= elems + q->tail)
 			return NULL;
-		return current++;
+		return (void **)current++;
 	} else {
-		if (current < q->elems + q->tail - 1)
-			return current++;
-		if (current < q->elems + q->head)
+		if (current < elems + q->tail - 1)
+			return (void **)current++;
+		if (current < elems + q->head)
 			return NULL;
-		if (current < q->elems + q->max - 1)
-			return current++;
-		return q->elems;
+		if (current < elems + q->max - 1)
+			return (void **)current++;
+		return (void **)elems;
 	}
 }
 

--- a/src/utils/queue.c
+++ b/src/utils/queue.c
@@ -14,13 +14,13 @@ struct aml_queue *aml_queue_create(const size_t max)
 {
 	struct aml_queue *q;
 
-	q = AML_INNER_MALLOC_ARRAY(max, void*, struct aml_queue);
+	q = AML_INNER_MALLOC_ARRAY(max, void *, struct aml_queue);
 	if (q == NULL)
 		return NULL;
 	q->max = max;
 	q->head = 0;
 	q->tail = 0;
-	q->elems = AML_INNER_MALLOC_GET_ARRAY(q, void*, struct aml_queue);
+	q->elems = AML_INNER_MALLOC_GET_ARRAY(q, void *, struct aml_queue);
 	return q;
 }
 
@@ -37,17 +37,58 @@ void aml_queue_destroy(struct aml_queue *q)
 	free(q);
 }
 
+void **aml_queue_head(struct aml_queue *q)
+{
+	if (q->max == 0 || aml_queue_len(q) == 0)
+		return NULL;
+	return &q->elems[q->head];
+}
+
+void **aml_queue_next(struct aml_queue *q, void **current)
+{
+	if (q == NULL || q->tail == q->head)
+		return NULL;
+	// Out of bounds return null
+	if (current < q->elems || current >= q->elems + q->max)
+		return NULL;
+	// Empty Queue
+	if (q->tail == q->head)
+		return NULL;
+	// End of queue
+	if (current == q->elems + q->tail - 1)
+		return NULL;
+	// special value query head
+	if (current == NULL)
+		return aml_queue_head(q);
+	// All element are contiguous.
+	if (q->tail > q->head) {
+		// Out of bounds
+		if (current < q->elems + q->head ||
+		    current >= q->elems + q->tail)
+			return NULL;
+		return current++;
+	} else {
+		if (current < q->elems + q->tail - 1)
+			return current++;
+		if (current < q->elems + q->head)
+			return NULL;
+		if (current < q->elems + q->max - 1)
+			return current++;
+		return q->elems;
+	}
+}
+
 static struct aml_queue *aml_queue_extend(struct aml_queue *q)
 {
 	const size_t len = q->max;
 	const size_t head = q->head;
 	const size_t tail = q->tail;
 
-	q = realloc(q,
-		    AML_SIZEOF_ALIGNED_ARRAY(2*len, void*, struct aml_queue));
+	q = realloc(q, AML_SIZEOF_ALIGNED_ARRAY(2 * len, void *,
+	                                        struct aml_queue));
 	if (q == NULL)
 		return NULL;
-	q->elems = AML_INNER_MALLOC_GET_ARRAY(q, void*, struct aml_queue);
+	q->elems = AML_INNER_MALLOC_GET_ARRAY(q, void *, struct aml_queue);
 	q->max = len * 2;
 
 	// If element are contiguous, no need for memmove.
@@ -55,17 +96,14 @@ static struct aml_queue *aml_queue_extend(struct aml_queue *q)
 		return q;
 
 	// head is right to tail and smaller than tail then move it at the end.
-	if (len-head < tail) {
+	if (len - head < tail) {
 		q->head = q->max - len + head;
-		memmove(q->elems + q->head,
-			q->elems + head,
-			(len - head) * sizeof(void *));
+		memmove(q->elems + q->head, q->elems + head,
+		        (len - head) * sizeof(void *));
 	}
 	// tail is left to head and smaller than head then move it after head.
 	else {
-		memmove(q->elems + len,
-			q->elems,
-			tail * sizeof(void *));
+		memmove(q->elems + len, q->elems, tail * sizeof(void *));
 		q->tail = len + tail;
 	}
 
@@ -133,9 +171,8 @@ void *aml_queue_take(struct aml_queue *q, void *element)
 		// move elements after the one removed by one to the left.
 		for (size_t i = q->head; i < q->tail; i++) {
 			if (q->elems[i] == element) {
-				memmove(q->elems + i,
-					q->elems + i + 1,
-					sizeof(void *) * (q->tail - i - 1));
+				memmove(q->elems + i, q->elems + i + 1,
+				        sizeof(void *) * (q->tail - i - 1));
 				q->tail--;
 				return element;
 			}
@@ -149,9 +186,8 @@ void *aml_queue_take(struct aml_queue *q, void *element)
 		// when the element is between 0 and tail.
 		for (size_t i = 0; i < q->tail; i++) {
 			if (q->elems[i] == element) {
-				memmove(q->elems + i,
-					q->elems + i + 1,
-					sizeof(void *) * (q->tail - i - 1));
+				memmove(q->elems + i, q->elems + i + 1,
+				        sizeof(void *) * (q->tail - i - 1));
 				q->tail--;
 				return element;
 			}
@@ -162,14 +198,12 @@ void *aml_queue_take(struct aml_queue *q, void *element)
 		// 1 to tail by one to the left.
 		for (size_t i = q->head; i < q->max; i++) {
 			if (q->elems[i] == element) {
-				memmove(q->elems + i,
-					q->elems + i + 1,
-					sizeof(void *) * (q->max - i - 1));
+				memmove(q->elems + i, q->elems + i + 1,
+				        sizeof(void *) * (q->max - i - 1));
 				q->elems[q->max - 1] = q->elems[0];
 				if (q->tail > 0) {
-					memmove(q->elems,
-						q->elems + 1,
-						sizeof(void *) * (q->tail - 1));
+					memmove(q->elems, q->elems + 1,
+					        sizeof(void *) * (q->tail - 1));
 					q->tail--;
 				} else
 					q->tail = q->max - 1;


### PR DESCRIPTION
Fix deadlocks and incoherent state issues in the queue scheduler.
When waiting for a task to finish, the waiter would only look into `doneq` and `workq` for tasks.
If no task is present then the caller was hanging on until a task was ready.

Now, the caller wil not hang anymore when waiting for work done while no task is waiting for execution, being executed or executed. It requires to lock the whole scheduler state and probe all queues for tasks and all threads to see if work in being done.
Therefore, the queue scheduler adds an array of flags that is checked by the waiting caller, along with the queues state
when waiting for a task to finish.