### PR TITLE
[ci] improve doc validation

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -24,3 +24,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: /bin/license-eye -c .licenserc.yml -v debug header check
+  doc-nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: cachix/install-nix-action@v13
+        with:
+          nix_path: nixpkgs=channel:nixos-20.09
+      - run: nix-shell --command "./autogen.sh; ./configure --enable-doc; make html"

--- a/configure.ac
+++ b/configure.ac
@@ -327,6 +327,7 @@ cat <<EOF
 AML
 
 Version: $PACKAGE_VERSION
+Docs:    $docs
 
 FEATURES:
 ---------

--- a/include/aml/dma/linux.h
+++ b/include/aml/dma/linux.h
@@ -39,8 +39,8 @@ extern "C" {
 /**
  * Create a dma engine with a custom amount of workers.
  *
- * @param dma[out]: A pointer where to allocate the dma engine.
- * @param num_threads[in]: The number of workers running the dma operations.
+ * @param[out] dma: A pointer where to allocate the dma engine.
+ * @param[in] num_threads: The number of workers running the dma operations.
  * @return -AML_ENOMEM on error, exclusively caused when being out of memory.
  * @return AML_SUCCESS on success. On success, the created dma must be destroyed
  * with `aml_dma_linux_destroy()`.
@@ -50,14 +50,14 @@ int aml_dma_linux_create(struct aml_dma **dma, const size_t num_threads);
 /**
  * Delete a linux dma created with `aml_dma_linux_create()`.
  *
- * @param dma[in, out]: A pointer where the dma engine has been allocated.
+ * @param[in, out] dma: A pointer where the dma engine has been allocated.
  * The pointer content is set to NULL after deallocation.
  * @return AML_SUCCESS.
  */
 int aml_dma_linux_destroy(struct aml_dma **dma);
 
 /**
- * Pre instanciated linux dma engine.
+ * Pre instantiated linux dma engine.
  * The user may use this directly after a successful call to `aml_init()`.
  * This pointer is not valid anymore after `aml_finalize()` is called.
  */
@@ -95,8 +95,8 @@ struct aml_dma_linux_task_in {
  * This function calls the operator in `input` with its arguments
  * and stored the result error code in `output`.
  *
- * @param input[in]: A pointer to `struct aml_dma_linux_task_in`.
- * @param output[out]: A pointer to an `int` where to store the result
+ * @param[in] input: A pointer to `struct aml_dma_linux_task_in`.
+ * @param[out] output: A pointer to an `int` where to store the result
  * of the dma operator.
  */
 void aml_dma_linux_exec_request(struct aml_task_in *input,
@@ -126,8 +126,8 @@ int aml_dma_linux_request_create(struct aml_dma_data *data,
 /**
  * The linux dma `wait_request()` operator implementation.
  *
- * @param dma[in]: The dma engine where request has been posted.
- * @param req[in]: A pointer to a `struct aml_dma_linux_request`.
+ * @param[in] dma: The dma engine where request has been posted.
+ * @param[in] req: A pointer to a `struct aml_dma_linux_request`.
  */
 int aml_dma_linux_request_wait(struct aml_dma_data *dma,
                                struct aml_dma_request **req);
@@ -135,8 +135,8 @@ int aml_dma_linux_request_wait(struct aml_dma_data *dma,
 /**
  * The linux dma `destroy_request()` operator implementation.
  *
- * @param dma[in]: unused.
- * @param req[in]: A pointer to a `struct aml_dma_linux_request`.
+ * @param[in] dma: unused.
+ * @param[in] req: A pointer to a `struct aml_dma_linux_request`.
  * The pointer is set to NULL.
  */
 int aml_dma_linux_request_destroy(struct aml_dma_data *dma,
@@ -151,9 +151,9 @@ int aml_dma_linux_request_destroy(struct aml_dma_data *dma,
  * - Dense source and destination layouts.
  *
  * @see aml_layout_dense
- * @param dst[out]: The destination dense layout.
- * @param src[in]: The source dense layout.
- * @param arg[in]: Unused.
+ * @param[out] dst: The destination dense layout.
+ * @param[in] src: The source dense layout.
+ * @param[in] arg: Unused.
  */
 int aml_dma_linux_copy_1D(struct aml_layout *dst,
                           const struct aml_layout *src,

--- a/include/aml/utils/async.h
+++ b/include/aml/utils/async.h
@@ -98,7 +98,7 @@ struct aml_task *aml_sched_wait_any(struct aml_sched *pool);
 /**
  * Create a pool of threads polling work from a common FIFO queue.
  *
- * @param nt[in]: The number of threads in the pool to execute tasks in the
+ * @param[in] nt: The number of threads in the pool to execute tasks in the
  * queue. If nt == 0 then progress is made from caller thread on call to
  * `aml_sched_wait_task()` and `aml_sched_wait_any()`.
  * @return An initialized task scheduler on success.
@@ -110,7 +110,7 @@ struct aml_sched *aml_queue_sched_create(const size_t nt);
 /**
  * Destroy a task scheduler created with `aml_queue_sched_create()`
  *
- * @param sched[in,out]: A pointer to the scheduler to destroy.
+ * @param[in, out] sched: A pointer to the scheduler to destroy.
  * The pointer content is set to NULL.
  */
 void aml_queue_sched_destroy(struct aml_sched **sched);


### PR DESCRIPTION
The readthedocs builder doesn't always fail on errors. This PR reintroduce our own doc build step to make sure that we're not building bad docs.