### PR TITLE
[doc/fix] fix typo in doc build checks

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -33,4 +33,4 @@ jobs:
       - uses: cachix/install-nix-action@v13
         with:
           nix_path: nixpkgs=channel:nixos-20.09
-      - run: nix-shell --command "./autogen.sh; ./configure --enable-doc; make html"
+      - run: nix-shell --command "./autogen.sh; ./configure --enable-docs; make html"

--- a/include/aml.h
+++ b/include/aml.h
@@ -1062,7 +1062,6 @@ int aml_dma_wait(struct aml_dma *dma, struct aml_dma_request **req);
  * be destroyed with `aml_dma_wait()`.
  *
  * @param[in, out] dma: n initialized DMA structure.
- * @param[in, out] req: a DMA request obtained using aml_dma_async_*() calls.
  * @return 0 if successful; an error code otherwise.
  **/
 int aml_dma_barrier(struct aml_dma *dma);


### PR DESCRIPTION
Wrong flag in the doc nix build check for CI, resulting in new bugs
getting through on the doc building side.