### PR TITLE
[ci] always displays clang format diff

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,6 +17,7 @@ jobs:
           if [ ! -z "$lint" ]; then echo "format errors, inspect the clang-format-diff artifact for info"; exit 1; else exit 0; fi
         shell: bash
       - name: output clang format diff
+        if: always()
         run: cat ./clang-format-diff
   license-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Make sure the job logs always contain the clang format diff for easier
debugging of the style checks.