### PR TITLE
Unification of backend activation and path customization

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,7 +12,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - run: sudo apt-get update
-      - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libhwloc-dev
+      - run: sudo apt-get install -y gcc make autoconf automake libtool pkgconf libhwloc-dev
       - name: configure
         run: |
           ./autogen.sh
@@ -38,7 +38,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - run: sudo apt-get update
-      - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libhwloc-dev
+      - run: sudo apt-get install -y gcc make autoconf automake libtool pkgconf libhwloc-dev
       - name: configure
         run: |
           ./autogen.sh
@@ -67,7 +67,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - run: sudo apt-get update
-      - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config hwloc libhwloc-dev valgrind
+      - run: sudo apt-get install -y gcc make autoconf automake libtool pkgconf hwloc libhwloc-dev valgrind
       - run: hwloc-gather-cpuid
       - name: configure
         run: |
@@ -108,7 +108,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - run: sudo apt-get update
-      - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libhwloc-dev
+      - run: sudo apt-get install -y gcc make autoconf automake libtool pkgconf libhwloc-dev
       - name: configure
         run: |
           ./autogen.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
           path: aml
           fetch-depth: 0
       - run: sudo apt-get update
-      - run: sudo apt-get install -y gcc make autoconf automake libtool pkg-config libhwloc-dev
+      - run: sudo apt-get install -y gcc make autoconf automake libtool pkgconf libhwloc-dev
       - run: mkdir $GITHUB_WORKSPACE/$INSTALL_PATH
       - name: aml install 
         run: |

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,28 @@ m4_define([VERSION_MINOR], m4_argn(2, VERSION_FIELDS))
 m4_define([VERSION_PATCH], m4_argn(3, VERSION_FIELDS))
 m4_define([VERSION_REVISION], m4_argn(4, VERSION_FIELDS))
 
+# Utils functions
+##################
+
+dnl AML_HAVE_DEFINE_WITH_MODULES(VARIABLE-PREFIX, MODULES,
+dnl   [DESCRIPTION], [DEFAULT])
+dnl ------------------------------------------------------
+dnl
+dnl Convenience macro to run AM_CONDITIONAL and AC_DEFINE after
+dnl PKG_WITH_MODULES check. HAVE_[VARIABLE-PREFIX] is exported as make
+dnl and preprocessor variable.
+AC_DEFUN([AML_HAVE_DEFINE_WITH_MODULES],
+[
+PKG_HAVE_WITH_MODULES([$1],[$2],[$3],[$4])
+if test "$AS_TR_SH([with_]m4_tolower([$1]))" = "yes"; then
+   have_[$1]=1
+else
+   have_[$1]=0
+fi
+AC_DEFINE([HAVE_][$1], $aml_have_pkg, [Supports ]m4_tolower([$1]))
+AC_SUBST([HAVE_][$1],[$have_[$1]])
+])dnl PKG_HAVE_DEFINE_WITH_MODULES
+
 # Init build tools
 ##################
 
@@ -117,205 +139,65 @@ AC_CHECK_LIB(numa, mbind,,[AC_MSG_ERROR([AML requires libnuma.])])
 # Hwloc support
 ###############
 
-# The directory where to look for hwloc. If no, we try to detect it automatically.
-hwloc_dir=no
-# Whether hwloc was successfully detected (0|1). 
-have_hwloc=0
-# Whether the user wants hwloc: (yes|no|check)
-# yes: the package is required
-# no: the package should not be checked.
-# check: autodetect the package and enable it if it was found.
-want_hwloc=check
-
-AC_ARG_WITH([hwloc],
-	[AS_HELP_STRING([--with-hwloc@<:@=yes|no|DIR@:>@],
-		[Support hwloc backend and features in the library  (default is check)])],
-	[if test "x$withval" = "xno"; then
-		want_hwloc=no
-	elif test "x$withval" = "xyes"; then
-	     	want_hwloc=yes
-	else
-		want_hwloc=yes
-		hwloc_dir=$withval
-	fi],[want_hwloc="check"])
-
-# The default check is to rely on pkg-config for detection.
-AS_IF([test "$want_hwloc" = "check" ||
-       test "$want_hwloc" = "yes" &&
-       test "$hwloc_dir" = "no"], [
-   PKG_CHECK_MODULES([HWLOC], [hwloc >= 2.1], [have_hwloc=1], [have_hwloc=0])
-])
-if test "$want_hwloc" != "no" &&
-   test "$hwloc_dir" != "no"; then
-   # The user requires a specific location for where to find hwloc.
-   # We use the classic headers and library detection and fail if detection fails.
-   HWLOC_CFLAGS=-I$hwloc_dir/include
-   HWLOC_LIBS="-L$hwloc_dir/lib"
-   saved_LIBS=$LIBS
-   saved_CFLAGS=$CFLAGS
-   LIBS="$HWLOC_LIBS $LIBS"
-   CFLAGS="$HWLOC_CFLAGS $CFLAGS"
-   HWLOC_LIBS="$HWLOC_LIBS -lhwloc"
-   AC_CHECK_HEADER([hwloc.h],,[AC_MSG_ERROR([hwloc.h header not found.])])
-   AC_CHECK_LIB(hwloc, hwloc_topology_init,, AC_MSG_ERROR([could not find hwloc library]))
-   LIBS="$saved_LIBS"
-   CFLAGS="$saved_CFLAGS"
-   have_hwloc=1
-   AC_SUBST(HWLOC_CFLAGS)
-   AC_SUBST(HWLOC_LIBS)
-fi
-if test "$want_hwloc" == "yes" &&
-   test "$have_hwloc" == "0"; then
-   AC_MSG_ERROR([hwloc required but not found.])
-fi
-
-# We export substitutions and defines if needed.
-if test "$have_hwloc" = "1"; then
-   AC_DEFINE([HAVE_HWLOC], [1], "hwloc library with ABI > 2.0 is installed.")
-fi
-AM_CONDITIONAL([HAVE_HWLOC], [test "$have_hwloc" = "1"])
-AC_DEFINE_UNQUOTED([HAVE_HWLOC], [$have_hwloc], [Whether aml support hwloc library calls.])
-AC_SUBST([HAVE_HWLOC],[$have_hwloc])
+AML_HAVE_DEFINE_WITH_MODULES(HWLOC, [hwloc >= 2.1],,)
 
 # OpenCL support
 ###############
 
-# The directory where to look for opencl. If no, we try to detect it automatically.
-opencl_dir=no
-# Whether opencl was successfully detected (0|1). 
-have_opencl=0
-# Whether the user wants opencl: (yes|no|check)
-# yes: the package is required
-# no: the package should not be checked.
-# check: autodetect the package and enable it if it was found.
-want_opencl=check
-
-AC_ARG_WITH([opencl],
-	[AS_HELP_STRING([--with-opencl@<:@=yes|no|DIR@:>@],
-		[Support opencl backend and features in the library  (default is check)])],
-	[if test "x$withval" = "xno"; then
-		want_opencl=no
-	elif test "x$withval" = "xyes"; then
-	     	want_opencl=yes
-	else
-		want_opencl=yes
-		opencl_dir=$withval
-	fi],[want_opencl="check"])
-
-AS_IF([test "$want_opencl" = "check" ||
-       test "$want_opencl" = "yes" &&
-       test "$opencl_dir" = "no" ], [
-   # The default check is to rely on pkg-config for detection.
-   PKG_CHECK_MODULES([OPENCL], [OpenCL >= 2.1], [have_opencl=1], [have_opencl=0])
-])
-if test "$want_opencl" != "no" &&
-     test "$opencl_dir" != "no"; then
-   # The user requires a specific location for where to find opencl.
-   # We use the classic headers and library detection and fail if detection fails.
-   OPENCL_CFLAGS=-I$opencl_dir/include
-   OPENCL_LIBS="-L$opencl_dir/lib"
-   saved_LIBS=$LIBS
-   saved_CFLAGS=$CFLAGS
-   LIBS="$OPENCL_LIBS $LIBS"
-   CFLAGS="$OPENCL_CFLAGS $CFLAGS"
-   OPENCL_LIBS="$OPENCL_LIBS -lOpenCL"
-   AC_CHECK_HEADER([CL/opencl.h],,[AC_MSG_ERROR([opencl.h header not found.])])
-   AC_CHECK_LIB(OpenCL, clGetPlatformIDs,, AC_MSG_ERROR([could not find opencl library]))
-   LIBS="$saved_LIBS"
-   CFLAGS="$saved_CFLAGS"
-   have_opencl=1
-   AC_SUBST(OPENCL_CFLAGS)
-   AC_SUBST(OPENCL_LIBS)
-fi
-if test "$want_opencl" == "yes" &&
-   test "$have_opencl" == "0"; then
-   AC_MSG_ERROR([opencl required but not found.])
-fi
-
-# We export substitutions and defines if needed.
-if test "$have_opencl" = "1"; then
-   AC_DEFINE([HAVE_OPENCL], [1], "opencl library with ABI > 2.0 is installed.")
-fi
-AM_CONDITIONAL([HAVE_OPENCL], [test "$have_opencl" = "1"])
-AC_DEFINE_UNQUOTED([HAVE_OPENCL], [$have_opencl], [Whether aml support opencl library calls.])
-AC_SUBST([HAVE_OPENCL],[$have_opencl])
+AML_HAVE_DEFINE_WITH_MODULES([OPENCL], [OpenCL >= 2.1],,)
 
 # Level Zero Support
 ####################
 
-# The directory where to look for ze. If no, we try to detect it automatically.
-ze_dir=no
-# Whether ze was successfully detected (0|1). 
-have_ze=0
-# Whether the user wants ze: (yes|no|check)
-# yes: the package is required
-# no: the package should not be checked.
-# check: autodetect the package and enable it if it was found.
-want_ze=check
+# Define --with-ze option and detect with pkg-config
+# De do not export variables yet because we want to try a fallback method if
+# this one fails.
+PKG_WITH_MODULES([ZE], [libze_loader >= 1.0], have_ze=1, have_ze=0,,)
 
-AC_ARG_WITH([ze],
-	[AS_HELP_STRING([--with-ze@<:@=yes|no|DIR@:>@],
-		[Support ze backend and features in the library  (default is check)])],
-	[if test "x$withval" = "xno"; then
-		want_ze=no
-	elif test "x$withval" = "xyes"; then
-	     	want_ze=yes
-	else
-		want_ze=yes
-		ze_dir=$withval
-	fi],[want_ze="check"])
-
-AS_IF([test "$want_ze" != "no" &&
-       test "$ze_dir" == "no"], [
-   # The default check is to rely on pkg-config for detection.
-   PKG_CHECK_MODULES([ZE], [libze_loader >= 1.0], [have_ze=1], [have_ze=0])
-])
-if test "$want_ze" != "no" &&
+# This is the fallback method. It used only if the user requests ze support.
+if test "x$with_ze" = "xyes" &&
    test "$have_ze" = "0"; then
-   ZE_CFLAGS=""
-   ZE_LIBS=""
-   if test "$ze_dir" != "no"; then
-      # The user requires a specific location for where to find ze.
-      ZE_CFLAGS=-I$ze_dir/include
-      ZE_LIBS=-L$ze_dir/lib
-   fi
+   # Setup user flags for configure detection.
    saved_LIBS=$LIBS
    saved_CFLAGS=$CFLAGS
-   LIBS="$ZE_LIBS $LIBS"
+   LIBS="$ZE_LDFLAGS $LIBS"
    CFLAGS="$ZE_CFLAGS $CFLAGS"
+   # Check header and libs
    AC_CHECK_HEADER([level_zero/ze_api.h], [have_ze_header=1], [have_ze_header=0])
    AC_SEARCH_LIBS([zeInit], [ze_loader], [have_libze=1], [have_libze=0])
-   if test "$have_ze_header" = "1" &&
-      test "$have_libze" = "1"; then
-     AC_MSG_CHECKING([ze_api version >= 1.0])
-     AC_RUN_IFELSE([AC_LANG_PROGRAM(
+   # Check version
+   AC_MSG_CHECKING([ze_api version >= 1.0])
+   AC_RUN_IFELSE([AC_LANG_PROGRAM(
      [[#include<level_zero/ze_api.h>]],
      [[return ZE_API_VERSION_CURRENT < ZE_MAKE_VERSION( 1, 0 )]]
      )],
      [have_ze_version=yes],
      [have_ze_version=no])
-     AC_MSG_RESULT([$have_ze_version])
-   fi
+   AC_MSG_RESULT([$have_ze_version])
+   # Restore libs and cflags.
    LIBS="$saved_LIBS"
    CFLAGS="$saved_CFLAGS"
-   
+
+   # If all detection steps succeeded
    if test "$have_ze_header" = "1" &&
       test "$have_libze" = "1" &&
-      test "x$have_ze_version" = "xyes"; then
-         ZE_LIBS="$ZE_LIBS $ac_cv_search_zeInit"
+      test "$have_ze_version" = "yes"; then
+         ZE_LDFLAGS="$ZE_LDFLAGS $ac_cv_search_zeInit"
       	 have_ze=1
-   	 AC_SUBST(ZE_CFLAGS)
-   	 AC_SUBST(ZE_LIBS)
    fi
 fi
-if test "$want_ze" == "yes" &&
-   test "$have_ze" == "0"; then
-   AC_MSG_ERROR([ze required but not found.])
-fi
 
-# We export substitutions and defines if needed.
+# We export flags with what has been detected or not.
+AC_SUBST(ZE_CFLAGS)
+AC_SUBST(ZE_LDFLAGS)
+AC_DEFINE_UNQUOTED([HAVE_ZE], [$have_ze], "ze library with ABI > 2.0 is installed.")
+AM_CONDITIONAL([HAVE_ZE], [test "$have_ze" = "1"])
+AC_SUBST([HAVE_ZE],[$have_ze])
+
+# If ze backend is used, we checked earlier whether ze pointers can be used
+# as openmp target pointers. Here we print a message to the user on whether
+# The support has been detected or not, and a hint of what to do if not.
 if test "$have_ze" = "1"; then
-   AC_DEFINE([HAVE_ZE], [1], "ze library with ABI > 2.0 is installed.")
    if test "$have_omptarget" = "1"; then
      INTEL_OMP_ZE_BACKEND_INTEROPERABILITY_MSG="OPENMP INTEROPERABILITY: yes\
 Make sure to enable OpenMP LEVEL0 backend with: export LIBOMPTARGET_PLUGIN=LEVEL0
@@ -326,9 +208,6 @@ Try using: ./configure CC=icx --with-openmp-flags=\"-fiopenmp -fopenmp-targets=s
      "
    fi
 fi
-AM_CONDITIONAL([HAVE_ZE], [test "$have_ze" = "1"])
-AC_DEFINE_UNQUOTED([HAVE_ZE], [$have_ze], [Whether aml support ze library calls.])
-AC_SUBST([HAVE_ZE],[$have_ze])
 
 # check doxygen + sphinx for documentation build
 ################################################

--- a/configure.ac
+++ b/configure.ac
@@ -164,7 +164,7 @@ if test "$want_hwloc" != "no" &&
    AC_SUBST(HWLOC_CFLAGS)
    AC_SUBST(HWLOC_LIBS)
 fi
-if test "$want_hwloc" != "no" &&
+if test "$want_hwloc" == "yes" &&
    test "$have_hwloc" == "0"; then
    AC_MSG_ERROR([hwloc required but not found.])
 fi
@@ -227,7 +227,7 @@ if test "$want_opencl" != "no" &&
    AC_SUBST(OPENCL_CFLAGS)
    AC_SUBST(OPENCL_LIBS)
 fi
-if test "$want_opencl" != "no" &&
+if test "$want_opencl" == "yes" &&
    test "$have_opencl" == "0"; then
    AC_MSG_ERROR([opencl required but not found.])
 fi
@@ -308,7 +308,7 @@ if test "$want_ze" != "no" &&
    	 AC_SUBST(ZE_LIBS)
    fi
 fi
-if test "$want_ze" != "no" &&
+if test "$want_ze" == "yes" &&
    test "$have_ze" == "0"; then
    AC_MSG_ERROR([ze required but not found.])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -289,7 +289,7 @@ if test "x$have_nvcc" = "xyes"; then
 	AC_CHECK_HEADER([cuda_runtime.h],,
 			[AC_MSG_ERROR([could not find cuda_runtime.h])])
 	AC_CHECK_LIB(cudart, cudaLaunchHostFunc,,
-		     AC_MSG_ERROR([could not find cudart library]))w
+		     AC_MSG_ERROR([could not find cudart library]))
 	LIBS=$saved_LIBS
 	CFLAGS=$saved_CFLAGS
 	have_cuda=1

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ else
    AS_TR_SH([have_]m4_tolower([$1]))=0
 fi
 AC_DEFINE_UNQUOTED([HAVE_][$1], [$[have_]m4_tolower([$1])], [Supports ]m4_tolower([$1]))
-AC_SUBST([HAVE_][$1],[$have_[$1]])
+AC_SUBST([HAVE_][$1],[$[have_]m4_tolower([$1])])
 ])dnl PKG_HAVE_DEFINE_WITH_MODULES
 
 # Init build tools

--- a/configure.ac
+++ b/configure.ac
@@ -117,10 +117,59 @@ AC_CHECK_LIB(numa, mbind,,[AC_MSG_ERROR([AML requires libnuma.])])
 # Hwloc support
 ###############
 
-PKG_CHECK_MODULES([HWLOC], \
-                  [hwloc >= 2.1],   \
-                  [have_hwloc=1], \
-                  [have_hwloc=0])
+# The directory where to look for hwloc. If no, we try to detect it automatically.
+hwloc_dir=no
+# Whether hwloc was successfully detected (0|1). 
+have_hwloc=0
+# Whether the user wants hwloc: (yes|no|check)
+# yes: the package is required
+# no: the package should not be checked.
+# check: autodetect the package and enable it if it was found.
+want_hwloc=check
+
+AC_ARG_WITH([hwloc],
+	[AS_HELP_STRING([--with-hwloc@<:@=yes|no|DIR@:>@],
+		[Support hwloc backend and features in the library  (default is check)])],
+	[if test "x$withval" = "xno"; then
+		want_hwloc=no
+	elif test "x$withval" = "xyes"; then
+	     	want_hwloc=yes
+	else
+		want_hwloc=yes
+		hwloc_dir=$withval
+	fi],[want_hwloc="check"])
+
+# The default check is to rely on pkg-config for detection.
+AS_IF([test "$want_hwloc" = "check" ||
+       test "$want_hwloc" = "yes" &&
+       test "$hwloc_dir" = "no"], [
+   PKG_CHECK_MODULES([HWLOC], [hwloc >= 2.1], [have_hwloc=1], [have_hwloc=0])
+])
+if test "$want_hwloc" != "no" &&
+   test "$hwloc_dir" != "no"; then
+   # The user requires a specific location for where to find hwloc.
+   # We use the classic headers and library detection and fail if detection fails.
+   HWLOC_CFLAGS=-I$hwloc_dir/include
+   HWLOC_LIBS="-L$hwloc_dir/lib"
+   saved_LIBS=$LIBS
+   saved_CFLAGS=$CFLAGS
+   LIBS="$HWLOC_LIBS $LIBS"
+   CFLAGS="$HWLOC_CFLAGS $CFLAGS"
+   HWLOC_LIBS="$HWLOC_LIBS -lhwloc"
+   AC_CHECK_HEADER([hwloc.h],,[AC_MSG_ERROR([hwloc.h header not found.])])
+   AC_CHECK_LIB(hwloc, hwloc_topology_init,, AC_MSG_ERROR([could not find hwloc library]))
+   LIBS="$saved_LIBS"
+   CFLAGS="$saved_CFLAGS"
+   have_hwloc=1
+   AC_SUBST(HWLOC_CFLAGS)
+   AC_SUBST(HWLOC_LIBS)
+fi
+if test "$want_hwloc" != "no" &&
+   test "$have_hwloc" == "0"; then
+   AC_MSG_ERROR([hwloc required but not found.])
+fi
+
+# We export substitutions and defines if needed.
 if test "$have_hwloc" = "1"; then
    AC_DEFINE([HAVE_HWLOC], [1], "hwloc library with ABI > 2.0 is installed.")
 fi
@@ -131,12 +180,61 @@ AC_SUBST([HAVE_HWLOC],[$have_hwloc])
 # OpenCL support
 ###############
 
-PKG_CHECK_MODULES([OPENCL], \
-                  [OpenCL >= 2.1],   \
-                  [have_opencl=1], \
-                  [have_opencl=0])
+# The directory where to look for opencl. If no, we try to detect it automatically.
+opencl_dir=no
+# Whether opencl was successfully detected (0|1). 
+have_opencl=0
+# Whether the user wants opencl: (yes|no|check)
+# yes: the package is required
+# no: the package should not be checked.
+# check: autodetect the package and enable it if it was found.
+want_opencl=check
+
+AC_ARG_WITH([opencl],
+	[AS_HELP_STRING([--with-opencl@<:@=yes|no|DIR@:>@],
+		[Support opencl backend and features in the library  (default is check)])],
+	[if test "x$withval" = "xno"; then
+		want_opencl=no
+	elif test "x$withval" = "xyes"; then
+	     	want_opencl=yes
+	else
+		want_opencl=yes
+		opencl_dir=$withval
+	fi],[want_opencl="check"])
+
+AS_IF([test "$want_opencl" = "check" ||
+       test "$want_opencl" = "yes" &&
+       test "$opencl_dir" = "no" ], [
+   # The default check is to rely on pkg-config for detection.
+   PKG_CHECK_MODULES([OPENCL], [OpenCL >= 2.1], [have_opencl=1], [have_opencl=0])
+])
+if test "$want_opencl" != "no" &&
+     test "$opencl_dir" != "no"; then
+   # The user requires a specific location for where to find opencl.
+   # We use the classic headers and library detection and fail if detection fails.
+   OPENCL_CFLAGS=-I$opencl_dir/include
+   OPENCL_LIBS="-L$opencl_dir/lib"
+   saved_LIBS=$LIBS
+   saved_CFLAGS=$CFLAGS
+   LIBS="$OPENCL_LIBS $LIBS"
+   CFLAGS="$OPENCL_CFLAGS $CFLAGS"
+   OPENCL_LIBS="$OPENCL_LIBS -lOpenCL"
+   AC_CHECK_HEADER([CL/opencl.h],,[AC_MSG_ERROR([opencl.h header not found.])])
+   AC_CHECK_LIB(OpenCL, clGetPlatformIDs,, AC_MSG_ERROR([could not find opencl library]))
+   LIBS="$saved_LIBS"
+   CFLAGS="$saved_CFLAGS"
+   have_opencl=1
+   AC_SUBST(OPENCL_CFLAGS)
+   AC_SUBST(OPENCL_LIBS)
+fi
+if test "$want_opencl" != "no" &&
+   test "$have_opencl" == "0"; then
+   AC_MSG_ERROR([opencl required but not found.])
+fi
+
+# We export substitutions and defines if needed.
 if test "$have_opencl" = "1"; then
-   AC_DEFINE([HAVE_OPENCL], [1], "OpenCL library with ABI >= 2.1 is installed.")
+   AC_DEFINE([HAVE_OPENCL], [1], "opencl library with ABI > 2.0 is installed.")
 fi
 AM_CONDITIONAL([HAVE_OPENCL], [test "$have_opencl" = "1"])
 AC_DEFINE_UNQUOTED([HAVE_OPENCL], [$have_opencl], [Whether aml support opencl library calls.])
@@ -145,51 +243,79 @@ AC_SUBST([HAVE_OPENCL],[$have_opencl])
 # Level Zero Support
 ####################
 
-# PKG CONFIG detection
-PKG_CHECK_MODULES([ZE], \
-                  [libze_loader >= 1.0],   \
-                  [have_ze=1], \
-                  [have_ze=0])
+# The directory where to look for ze. If no, we try to detect it automatically.
+ze_dir=no
+# Whether ze was successfully detected (0|1). 
+have_ze=0
+# Whether the user wants ze: (yes|no|check)
+# yes: the package is required
+# no: the package should not be checked.
+# check: autodetect the package and enable it if it was found.
+want_ze=check
 
-# fallback detection
-if test "$have_ze" = "0"; then
-have_libze=0 # library check
-have_ze_header=0 # header check
-have_ze_version="no" # version check
+AC_ARG_WITH([ze],
+	[AS_HELP_STRING([--with-ze@<:@=yes|no|DIR@:>@],
+		[Support ze backend and features in the library  (default is check)])],
+	[if test "x$withval" = "xno"; then
+		want_ze=no
+	elif test "x$withval" = "xyes"; then
+	     	want_ze=yes
+	else
+		want_ze=yes
+		ze_dir=$withval
+	fi],[want_ze="check"])
 
-# library check
-AC_SEARCH_LIBS([zeInit], [ze_loader], [have_libze=1], [have_libze=0])
-
-# header check
-if test "$have_libze" = "1"; then
-   AC_CHECK_HEADER([level_zero/ze_api.h], [have_ze_header=1], [have_ze_header=0])
-fi
-
-# header version check
-if test "$have_ze_header" = "1"; then
-   AC_MSG_CHECKING([ze_api version >= 1.0])
-   AC_RUN_IFELSE([AC_LANG_PROGRAM(
-[[#include<level_zero/ze_api.h>]],
-[[return ZE_API_VERSION_CURRENT < ZE_MAKE_VERSION( 1, 0 )]]
-)],
-                 [have_ze_version=yes],
-		 [have_ze_version=no])
-   AC_MSG_RESULT([$have_ze_version])
-fi
-
-# All check passed ->
-if test "$have_ze_version" = "yes"; then
+AS_IF([test "$want_ze" != "no" &&
+       test "$ze_dir" == "no"], [
+   # The default check is to rely on pkg-config for detection.
+   PKG_CHECK_MODULES([ZE], [libze_loader >= 1.0], [have_ze=1], [have_ze=0])
+])
+if test "$want_ze" != "no" &&
+   test "$have_ze" = "0"; then
    ZE_CFLAGS=""
-   ZE_LIBS="$ac_cv_search_zeInit"
-   AC_SUBST(ZE_CFLAGS)
-   AC_SUBST(ZE_LIBS)
-   have_ze=1
+   ZE_LIBS=""
+   if test "$ze_dir" != "no"; then
+      # The user requires a specific location for where to find ze.
+      ZE_CFLAGS=-I$ze_dir/include
+      ZE_LIBS=-L$ze_dir/lib
+   fi
+   saved_LIBS=$LIBS
+   saved_CFLAGS=$CFLAGS
+   LIBS="$ZE_LIBS $LIBS"
+   CFLAGS="$ZE_CFLAGS $CFLAGS"
+   AC_CHECK_HEADER([level_zero/ze_api.h], [have_ze_header=1], [have_ze_header=0])
+   AC_SEARCH_LIBS([zeInit], [ze_loader], [have_libze=1], [have_libze=0])
+   if test "$have_ze_header" = "1" &&
+      test "$have_libze" = "1"; then
+     AC_MSG_CHECKING([ze_api version >= 1.0])
+     AC_RUN_IFELSE([AC_LANG_PROGRAM(
+     [[#include<level_zero/ze_api.h>]],
+     [[return ZE_API_VERSION_CURRENT < ZE_MAKE_VERSION( 1, 0 )]]
+     )],
+     [have_ze_version=yes],
+     [have_ze_version=no])
+     AC_MSG_RESULT([$have_ze_version])
+   fi
+   LIBS="$saved_LIBS"
+   CFLAGS="$saved_CFLAGS"
+   
+   if test "$have_ze_header" = "1" &&
+      test "$have_libze" = "1" &&
+      test "x$have_ze_version" = "xyes"; then
+         ZE_LIBS="$ZE_LIBS $ac_cv_search_zeInit"
+      	 have_ze=1
+   	 AC_SUBST(ZE_CFLAGS)
+   	 AC_SUBST(ZE_LIBS)
+   fi
 fi
-fi # test "$have_ze" = "0"
+if test "$want_ze" != "no" &&
+   test "$have_ze" == "0"; then
+   AC_MSG_ERROR([ze required but not found.])
+fi
 
-# If level zero is present and usable then declare it as such.
+# We export substitutions and defines if needed.
 if test "$have_ze" = "1"; then
-   AC_DEFINE([HAVE_ZE], [1], "Level Zero library and headers are available")
+   AC_DEFINE([HAVE_ZE], [1], "ze library with ABI > 2.0 is installed.")
    if test "$have_omptarget" = "1"; then
      INTEL_OMP_ZE_BACKEND_INTEROPERABILITY_MSG="OPENMP INTEROPERABILITY: yes\
 Make sure to enable OpenMP LEVEL0 backend with: export LIBOMPTARGET_PLUGIN=LEVEL0
@@ -201,7 +327,7 @@ Try using: ./configure CC=icx --with-openmp-flags=\"-fiopenmp -fopenmp-targets=s
    fi
 fi
 AM_CONDITIONAL([HAVE_ZE], [test "$have_ze" = "1"])
-AC_DEFINE_UNQUOTED([HAVE_ZE], [$have_ze], [Whether aml support intel level zero library calls.])
+AC_DEFINE_UNQUOTED([HAVE_ZE], [$have_ze], [Whether aml support ze library calls.])
 AC_SUBST([HAVE_ZE],[$have_ze])
 
 # check doxygen + sphinx for documentation build
@@ -284,7 +410,7 @@ if test "x$have_nvcc" = "xyes"; then
 	AC_CHECK_HEADER([cuda_runtime.h],,
 			[AC_MSG_ERROR([could not find cuda_runtime.h])])
 	AC_CHECK_LIB(cudart, cudaLaunchHostFunc,,
-		     AC_MSG_ERROR([could not find cudart library]))
+		     AC_MSG_ERROR([could not find cudart library]))w
 	LIBS=$saved_LIBS
 	CFLAGS=$saved_CFLAGS
 	have_cuda=1

--- a/configure.ac
+++ b/configure.ac
@@ -22,11 +22,11 @@ AC_DEFUN([AML_HAVE_DEFINE_WITH_MODULES],
 [
 PKG_HAVE_WITH_MODULES([$1],[$2],[$3],[$4])
 if test "$AS_TR_SH([with_]m4_tolower([$1]))" = "yes"; then
-   have_[$1]=1
+   AS_TR_SH([have_]m4_tolower([$1]))=1
 else
-   have_[$1]=0
+   AS_TR_SH([have_]m4_tolower([$1]))=0
 fi
-AC_DEFINE([HAVE_][$1], $aml_have_pkg, [Supports ]m4_tolower([$1]))
+AC_DEFINE_UNQUOTED([HAVE_][$1], [$[have_]m4_tolower([$1])], [Supports ]m4_tolower([$1]))
 AC_SUBST([HAVE_][$1],[$have_[$1]])
 ])dnl PKG_HAVE_DEFINE_WITH_MODULES
 

--- a/default.nix
+++ b/default.nix
@@ -7,11 +7,11 @@ let
       (_: pkgs: {
 
         aml = let
-          f = { stdenv, src, autoreconfHook, git, pkgconfig, numactl, hwloc }:
+          f = { stdenv, src, autoreconfHook, git, pkgconf, numactl, hwloc }:
             stdenv.mkDerivation {
               src = ./.;
               name = "aml";
-              nativeBuildInputs = [ autoreconfHook pkgconfig git ];
+              nativeBuildInputs = [ autoreconfHook pkgconf git ];
               buildInputs = [ hwloc numactl ];
             };
         in pkgs.lib.callPackageWith pkgs f { };


### PR DESCRIPTION
In order to ease the spack install process we make a uniform interface to enable/disable backends: hwloc, cuda, opencl, ze.
`--with-<backend>` options are unified by using `pkgconf` m4 macros.
This largely simplifies the work for hwloc and opencl. However, a special attention has to be given to (1) ze and (2) cuda.
(1) ze is not always installed with a `.pc` companion and the detection might fail even if it is installed in a standard path.
Therefore, we provide a fallback method to detect it.
(2) cuda detection is left untouched until we figure out how to deal with nvcc detection and pkg-config for cuda.

In order to customize the installation path of these backends, one can pass `./configure <backend>_CFLAGS <backend>_LDFLAGS` to override pkgconf path. For the case of cuda however, the path has to be specified with the `--with-cuda=path` option.