### PR TITLE
Overhaul Mapper Abstraction and Deepcopy

### DIFF
--- a/doc/tutorials/higher/0_deepcopy_linux.c
+++ b/doc/tutorials/higher/0_deepcopy_linux.c
@@ -14,6 +14,7 @@
 
 // Mapper includes
 #include "aml/higher/mapper.h"
+#include "aml/higher/mapper/deepcopy.h"
 
 // Allocation (linux)
 #include "aml/area/linux.h"
@@ -117,21 +118,20 @@ int eq_struct(const struct C *c, const struct C *_c)
 int main(int argc, char **argv)
 {
 	struct C *c, *_c;
+	aml_mapped_ptrs data;
 
 	// Init
 	assert(aml_init(&argc, &argv) == AML_SUCCESS);
-
 	c = init_struct();
 
 	// deepcopy
-	assert(aml_mapper_mmap(&struct_C_mapper, &_c, c, 1, &aml_area_linux,
-	                       NULL, aml_dma_linux, aml_dma_linux_copy_1D,
-	                       NULL) == AML_SUCCESS);
+	_c = aml_mapper_deepcopy(&data, (void *)c, &struct_C_mapper,
+	                         &aml_area_linux, NULL, NULL, aml_dma_linux,
+	                         NULL, aml_dma_linux_memcpy_op);
 	assert(eq_struct(c, _c));
 
 	// Cleanup
-	aml_mapper_munmap(&struct_C_mapper, _c, 1, c, &aml_area_linux,
-	                  aml_dma_linux, aml_dma_linux_copy_1D, NULL);
+	aml_mapper_deepfree(data);
 	free(c);
 	aml_finalize();
 	return 0;

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -12,6 +12,12 @@ include_aml_higher_HEADERS = \
 			      aml/higher/allocator/buddy.h \
 			      aml/higher/allocator/sized.h
 
+include_aml_mapperdir=$(includedir)/aml/mapper
+include_aml_mapper_HEADERS = \
+			      aml/higher/mapper/visitor.h \
+			      aml/higher/mapper/creator.h \
+			      aml/higher/mapper/deepcopy.h
+
 include_aml_replicasetdir=$(includedir)/aml/higher/replicaset
 include_aml_replicaset_HEADERS = 
 
@@ -77,4 +83,5 @@ noinst_include_internaldir = $(includedir)/internal
 noinst_include_internal_HEADERS = \
 				  internal/utarray.h \
 				  internal/uthash.h \
-				  internal/utlist.h
+				  internal/utlist.h \
+				  internal/utstack.h

--- a/include/aml/higher/mapper/creator.h
+++ b/include/aml/higher/mapper/creator.h
@@ -1,0 +1,321 @@
+/*******************************************************************************
+ * Copyright 2019 UChicago Argonne, LLC.
+ * (c.f. AUTHORS, LICENSE)
+ *
+ * This file is part of the AML project.
+ * For more info, see https://github.com/anlsys/aml
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+#ifndef AML_MAPPER_CREATOR_H
+#define AML_MAPPER_CREATOR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @addtogroup aml_mapper
+ *
+ * @{
+ **/
+
+/**
+ * The creator structure is a special structure visitor that copies the
+ * structure it visits as it is visiting it.
+ * It is meant to be used to implement the copy of complex
+ * structures with members in different memories.
+ *
+ * Note that the source structure
+ * must have a tree shape. At the moment, the creator does not support
+ * self references and multiple pointers to the same element.
+ *
+ * The copy process can be summarized as copying the source structure
+ * bit by bit on the host, overwriting fields pointers on host to point
+ * to the device memory where the corresponding field will be copied, and
+ * finally copying the host buffer to the device. The resulting copy,
+ * is packed in a contiguous buffer.
+ *
+ * In more details, the creator structure will perform a depth first visit
+ * of the source structure in successive steps.
+ * For each step, the creator state matches either a field in a parent
+ * structure or an element of an array field if the array field is an
+ * array of structs with descendants.
+ *
+ * When a step is performed, the current structure referenced by the creator
+ * in its current state is copied on the host in a buffer large enough to
+ * contain the whole structure to copy.
+ * The field of the host copy of the parent structure is overwritten with
+ * the pointer of the device memory where the current field will be copied
+ * in a single copy to the destination pointer at the very end.
+ *
+ * Since the creator state refers to the structure that is about to be
+ * copied, the user may perform one of these three actions:
+ * - Copy the field on host and overwrite parent pointer to this field
+ * (on the host) to point to the device memory where this field will be copied,
+ * and then move on to the next field;
+ * - "Branch out" by creating a new creator at the current point of visit
+ * that will map the current field and its descendants in a different
+ * host buffer and device mapped memory.
+ * - Connect a child field that is already to its parent instead of
+ * "branching out". The child field is assumed to be a valid instanciation of
+ * a structure described the mapper of the creator in its current state.
+ *
+ * Host buffer and device buffer are allocated to fit just enough data to
+ * map the structure, which is the size computed by a visitor that does not
+ * account for fields with a mapper that indicates to split the allocation.
+ * Therefore, when encountering such a flag in the constructor, the user
+ * can only take the "branch-out" option.
+ *
+ * @see `struct aml_mapper`
+ * @see `struct aml_mapper_visitor_state`
+ */
+struct aml_mapper_creator {
+	// Information on the current mapper, parent fields and relationship of
+	// ancestors with their parent.
+	// Note that the field device_ptr of stack, does not refer to a pointer
+	// in `device_memory` below but instead to a pointer of the structure
+	// that is being copied.
+	struct aml_mapper_visitor_state *stack;
+	// Target memory where host_memory is being copied at "finish()".
+	void *device_memory;
+	// Host buffer storing the ongoing construction of the structure
+	// to map. At the end of the construction, the buffer is copied to
+	// the device memory.
+	void *host_memory;
+	// device_memory and host_memory size in bytes.
+	size_t size;
+	// Offset in `host_memory` and `device_memory` buffers pointing to the
+	// beginning of free space.
+	size_t offset;
+	// Area where device_memory is allocated.
+	// NULL if device_memory is the same as host memory.
+	struct aml_area *device_area;
+	// Dma engine to copy from the source structure pointer to host.
+	// If the source struture is on host, this pointer can be NULL.
+	struct aml_dma *dma_src_host;
+	// Dma engine to copy from host to destination structure pointer.
+	struct aml_dma *dma_host_dst;
+	// Dma memcpy operator to copy from the source structure pointer to
+	// host. If the source struture in on host, this pointer can be NULL.
+	aml_dma_operator memcpy_src_host;
+	// Dma memcpy operator to copy from host to destination structure
+	// pointer.
+	aml_dma_operator memcpy_host_dst;
+};
+
+/**
+ * Allocate and instanciate a mapper creator to deep-copy a
+ * tree-like structure.
+ *
+ * Allocation will allocate two buffers, one in host memory and one in
+ * target `area`. Buffers will contain a packed copy of the entire
+ * structure.
+ *
+ * `dma_src_host` will be used to copy from the source structure
+ * `src_ptr` to the host buffer, while `dma_host_dst` will be used to copy
+ * the host buffer to the destination area buffer.
+ *
+ * After this call succeeds, the created mapper creator, will be in a ready
+ * state, ready to be iterated with `aml_mapper_creator_next()` to copy the
+ * source structure bit by bit on host. The final structure, will be copied to
+ * the destination `area` buffer, after iteration is finished when calling
+ * `aml_mapper_creator_finish()`.
+ *
+ * @param[out] out: A pointer where to store the instanciated mapper
+ * creator.
+ * @param[in] src_ptr: A pointer to the structure to copy. This structure
+ * will not be modified in the copy process.
+ * @param[in] size: A size large enough to fit the first chunk of the
+ * structure to copy. If no mapper in the hierarchy has the flag
+ * `AML_MAPPER_FLAG_SPLIT` set, this is the total size of the structure.
+ * `size` can be set to 0 if this not known at the time of the call.
+ * If `size` is 0, then the source structure will be visited to obtain this
+ * size.
+ * @param[in] mapper: The description of the structure pointed by `src_ptr`.
+ * @param[in] area: The area used to allocate the space where the source
+ * structure will be copied. `area` can be NULL if mapper flag
+ * `AML_MAPPER_FLAG_HOST` is set, meaning that no allocation but the host copy
+ * is performed.
+ * @param[in] area_opts: Options to configure area behavior.
+ * @param[in] dma_src_host: A copy engine to copy from the source pointer to
+ * the host executing this call. `dma_src_host` can be NULL if the source
+ * pointer is already on host.
+ * @param[in] dma_host_dst: A copy engine to copy from the host executing
+ * this call to a destination area buffer. `dma_host_dst` can be `NULL` if
+ * mapper flag `AML_MAPPER_FLAG_HOST` is set, meaning that the target copy is
+ * the internal host copy.
+ * @param[in] memcpy_src_host: The memcpy operator of `dma_src_host`.
+ * It can be NULL if `dma_src_host` is `NULL`.
+ * @param[in] memcpy_host_dst: The memcpy operator of `dma_host_dst`.
+ * It can be NULL if `dma_host_dst` is `NULL`.
+ * @return AML_SUCCESS on success.
+ * @return -AML_ENOMEM if there was not enough memory to allocate host
+ * buffer or to perform necessary operations.
+ * @return `aml_errno` if `aml_area_mmap()` call fails.
+ * @return Any error coming `dma_src_host` copied to obtain the source
+ * structure total size.
+ */
+int aml_mapper_creator_create(struct aml_mapper_creator **out,
+                              void *src_ptr,
+                              size_t size,
+                              struct aml_mapper *mapper,
+                              struct aml_area *area,
+                              struct aml_area_mmap_options *area_opts,
+                              struct aml_dma *dma_src_host,
+                              struct aml_dma *dma_host_dst,
+                              aml_dma_operator memcpy_src_host,
+                              aml_dma_operator memcpy_host_dst);
+
+/**
+ * This function is called to conclude a copy performed with a mapper
+ * creator. On success, this function will also take care of cleaning up the
+ * resource used by the creator, except of course the device pointer holding
+ * the copy.
+ *
+ * It will perform a copy of the host copy with embedded destination areas
+ * pointers to the destination area.
+ * After the copy succeed, the resources associated with the mapper creator
+ * are freed and the structure copy in the destination area is returned.
+ * The structure will be packed in a single buffer. The size of the buffer
+ * is also returned and can be used with the area used to create the
+ * destination structure to free the latter.
+ *
+ * This function may only be called after a call to
+ * `aml_mapper_creator_next()`, `aml_mapper_creator_connect()` or
+ * `aml_mapper_creator_branch()` with the same mapper creator returned
+ * `-AML_EDOM` meaning that everything has been copied from source
+ * structure to the host and the creator is ready to finish the job.
+ *
+ * @param[in] c: A mapper creator that finished copying and packing source
+ * structure on host.
+ * @param[out] ptr: Where to store the pointer to the copy of the copied
+ * structure.
+ * @param[out] size: Where to store the size of the copied structure.
+ * @return AML_SUCCESS on success.
+ * @return -AML_EINVAL if the user is attempting to finish a creator without
+ * copying everything there is to copy. If this is intended, use
+ * `aml_mapper_creator_abort()` instead.
+ * @return Any error from the dma engine used to copy from host to
+ * destination area.
+ */
+int aml_mapper_creator_finish(struct aml_mapper_creator *c,
+                              void **ptr,
+                              size_t *size);
+
+/**
+ * Destroy a mapper creator before the last iteration of the copy.
+ * This will free the device pointer currently built. If any branch were made
+ * from this creator, it is the user responsibility to handle the branches and
+ * finished branches pointers destruction separately. This function does not
+ * check its input is valid.
+ * @return AML_SUCCESS
+ */
+int aml_mapper_creator_abort(struct aml_mapper_creator *crtr);
+
+/**
+ * Perform the next step of the copy from source structure to host buffer.
+ *
+ * The function copies the current visited field to host, then move to the
+ * next field to copy.
+ * The next field to copy is obtained doing a depth-first visit as follow:
+ * 1. Go to the first field.
+ * 2. If there is no first field, go to next array element.
+ * 3. If there is no next array element, go to next sibling field.
+ * 4. If there is no sibling field, go to parent and then go to 2.
+ *
+ * If the current state of the creator holds a flag `AML_MAPPER_FLAG_SPLIT`,
+ * then the function will do nothing and return `-AML_EINVAL`. This flags
+ * means that the structure allocation must be split at this point. Moreover,
+ * there will not be enough room in the creator buffers to fit current field.
+ * In this case, the user has to use either `aml_mapper_creator_branch()` to
+ * deepcopy the corresponding field or `aml_mapper_creator_connect()` to connect
+ * an existing copy of the field. After one of these functions succeeds,
+ * the user can resume calling this function.
+ *
+ * @param[in, out] c: A mapper creator representing the current state of a
+ * structure copy from a source pointer to the host.
+ * @return AML_SUCCESS on success to process this step.
+ * @return -AML_EINVAL if the current field has the flag
+ * `AML_MAPPER_FLAG_SPLIT` set. In that case, the next call should be
+ * `aml_mapper_creator_branch()` or `aml_mapper_creator_connect()` instead.
+ * @return -AML_EDOM there is no next field to copy. In that case,
+ * the next call should be `aml_mapper_creator_finish()`.
+ * @return Any error from dma_src_host arising from copying source pointer
+ * to host.
+ *
+ * @see aml_mapper_creator_branch()
+ * @see aml_mapper_creator_finish()
+ */
+int aml_mapper_creator_next(struct aml_mapper_creator *c);
+
+/**
+ * Connect an already instanciated structure to the structure being constructed.
+ *
+ * This function shall be called after `aml_mapper_creator_next()` returns
+ * `-AML_EINVAL` with the same creator.
+ * The structure to connect must match the mapper associated with the current
+ * state of the creator. Moreover, this function expects that the mapper
+ * of the creator current state has the flag `AML_MAPPER_FLAG_SPLIT` set.
+ *
+ * @param[in, out] c: A creator in a "split" state.
+ * @param[in] ptr: The pointer to a constructed structure accurately described
+ * by the mapper of the current state of the creator.
+ * @return AML_SUCCESS on success, with the creator state advanced to the next
+ * element to copy.
+ * @return -AML_EDOM if there is nothing left to copy with the creator.
+ * @return -AML_EINVAL if the creator is NULL, of if it does not have the flag
+ * `AML_MAPPER_FLAG_SPLIT` set, or if `ptr` is NULL.
+ * @return -AML_ENOMEM if there was not enough memory to move the creator state
+ * to the next field to copy.
+ */
+int aml_mapper_creator_connect(struct aml_mapper_creator *c, void *ptr);
+
+/**
+ * Create a new mapper creator starting from the current creator state and
+ * connect the corresponding field and its descendants to the parent
+ * structure in the current mapper creator.
+ *
+ * Once the new creator is successfully initialized, it can be iterated
+ * independently and in a thread safe manner from the initial creator.
+ *
+ * This function should be called after `aml_mapper_creator_next()` returned
+ * `-AML_EINVAL` on the current mapper creator. After this function succeed,
+ * the user can resume calling `aml_mapper_creator_next()` on the initial
+ * creator to continue mapping parent structure. The whole structure, will
+ * be entirely mapped only when both the current creator and the new
+ * creator are finished.
+ *
+ * @param[out] out: A pointer where to store the new mapper creator.
+ * @param[in] c: The current mapper creator which should be in a state with
+ * the flag `AML_MAPPER_FLAG_SPLIT` set.
+ * @param[in] area: The area where to copy the structure of the new creator.
+ * @param[in] area_opts: Options for customizing area behavior.
+ * @param[in] dma_host_dst: A dma engine to copy data from host to `area`.
+ * @param[in] memcpy_host_dst: The memcpy operator for the dma engine.
+ *
+ * @return AML_SUCCESS on success.
+ * @return -AML_EDOM if there is nothing left to copy in the original
+ * creator after this call. In that case, the next call on orginial creator
+ * should be `aml_mapper_creator_finish()`.
+ * @return Any error from `aml_mapper_creator_create()` if the creation of
+ * the new creator failed.
+ *
+ * @see aml_mapper_creator_create()
+ */
+int aml_mapper_creator_branch(struct aml_mapper_creator **out,
+                              struct aml_mapper_creator *c,
+                              struct aml_area *area,
+                              struct aml_area_mmap_options *area_opts,
+                              struct aml_dma *dma_host_dst,
+                              aml_dma_operator memcpy_host_dst);
+
+/**
+ * @}
+ **/
+
+#ifdef __cplusplus
+}
+#endif
+#endif // AML_MAPPER_CREATOR_H

--- a/include/aml/higher/mapper/deepcopy.h
+++ b/include/aml/higher/mapper/deepcopy.h
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright 2019 UChicago Argonne, LLC.
+ * (c.f. AUTHORS, LICENSE)
+ *
+ * This file is part of the AML project.
+ * For more info, see https://github.com/anlsys/aml
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+#ifndef AML_MAPPER_DEEPCOPY_H
+#define AML_MAPPER_DEEPCOPY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @addtogroup aml_mapper
+ *
+ * @{
+ **/
+
+/**
+ * Data obtained as a result of a deepcopy operation used to free
+ * allocated pointers.
+ *
+ * This struct is implemented as a UT_array where elements are
+ * mapped pointers, with their size and the area which mapped them.
+ * The first element of this array it the pointer to the root of the
+ * data structure, i.e the deepcopied structure.
+ */
+typedef void *aml_mapped_ptrs;
+
+struct aml_mapped_ptr {
+	void *ptr;
+	size_t size;
+	struct aml_area *area;
+};
+
+void aml_mapped_ptr_destroy(void *ptr);
+
+/**
+ * Perform a deepcopy of a structure described with a `mapper` into an `area` of
+ * choice.
+ *
+ * The structure to copy may be on host or on any device.
+ * Regardless of whether the structure is on host or not, the structure will be
+ * copied on host first and then to the `area` of choice. Therefore, this
+ * function call may use as much memory as the structure to copy itself.
+ *
+ * Note that the structure to copy must have a tree topology, i.e no field
+ * should reference a parent node in the structure, or reference the same
+ * node as another field.
+ *
+ * This function requires that the pointer yielded in the desired area can be
+ * safely offseted (not dereferenced) from host as long as the result pointer
+ * is within the bounds of allocation. If the resulting pointer do not support
+ * this property, then using this function is undefined.
+ *
+ * @param out[out]: A pointer where to store the allocated pointers of this
+ * copy. This input must be used to cleanup the copy of the data structure
+ * later.
+ * @see aml_mapper_deepfree()
+ * @param ptr[in]: The pointer to the structure to copy.
+ * @param mapper[in]: The mapper describing the structure to copy.
+ * @param area[in]: The area where to allocate the copy.
+ * @param dma_src_host[in]: A dma engine to copy from the area of the source
+ * structure to copy to the host. This can be NULL if the source pointer is
+ * already a host pointer.
+ * @param dma_host_dst[in]: A dma engine to copy from the host to the area
+ * where the source structure is copied.
+ * @param memcpy_src_host[in]: The memcpy operator associated with
+ * `dma_src_host`. It can be NULL if `dma_src_host` is also NULL.
+ * @param memcpy_host_dst[in]: The memcpy operator associated with
+ * `dma_host_dst`.
+ * @return A pointer to the copy of the structure on success.
+ * @return NULL on error with aml_errno set as follow:
+ * + -AML_EINVAL if `out`, `ptr`, `mapper`, `area`, `dma_host_dst`,
+ * or `memcpy_host_dst` is NULL. This error might also be returned if one a
+ * pointer of a field to copy in the source structure is NULL.
+ * + Any error code created by area when to allocating data.
+ * + Any error code from a failing dma engine copy.
+ */
+void *aml_mapper_deepcopy(aml_mapped_ptrs *out,
+                          void *ptr,
+                          struct aml_mapper *mapper,
+                          struct aml_area *area,
+                          struct aml_area_mmap_options *area_opts,
+                          struct aml_dma *dma_src_host,
+                          struct aml_dma *dma_host_dst,
+                          aml_dma_operator memcpy_src_host,
+                          aml_dma_operator memcpy_host_dst);
+
+/**
+ * Release resources allocated with `aml_mapper_deepcopy()`.
+ * The area inside used to allocate the copy must still be valid when calling
+ * this function.
+ * @param data[in, out]: The structure returned as a result of a deepcopy.
+ * @return AML_SUCCESS on success.
+ * @return Any error code from `aml_area_munmap()` if it fails on a pointer.
+ * In this case, the last pointer in `data` structure will be the problematic
+ * one.
+ */
+int aml_mapper_deepfree(aml_mapped_ptrs data);
+
+/**
+ * @}
+ **/
+
+#ifdef __cplusplus
+}
+#endif
+#endif // AML_MAPPER_DEEPCOPY_H

--- a/include/aml/higher/mapper/deepcopy.h
+++ b/include/aml/higher/mapper/deepcopy.h
@@ -26,18 +26,20 @@ extern "C" {
  * allocated pointers.
  *
  * This struct is implemented as a UT_array where elements are
- * mapped pointers, with their size and the area which mapped them.
- * The first element of this array it the pointer to the root of the
- * data structure, i.e the deepcopied structure.
+ * mapped pointers (`struct aml_mapped_ptr`), with their size and the area
+ * which mapped them. The first element of this array is the pointer to the
+ * root of the data structure, i.e the deepcopied structure.
  */
 typedef void *aml_mapped_ptrs;
 
+/** Metadata of a piece of allocated structure used to free the latter. */
 struct aml_mapped_ptr {
 	void *ptr;
 	size_t size;
 	struct aml_area *area;
 };
 
+/** Cleanup pointer referred by a `struct aml_mapped_ptr`. */
 void aml_mapped_ptr_destroy(void *ptr);
 
 /**
@@ -46,8 +48,10 @@ void aml_mapped_ptr_destroy(void *ptr);
  *
  * The structure to copy may be on host or on any device.
  * Regardless of whether the structure is on host or not, the structure will be
- * copied on host first and then to the `area` of choice. Therefore, this
- * function call may use as much memory as the structure to copy itself.
+ * copied on host first and then to the `area` of choice. If the whole structure
+ * is to be copied on host (with `AML_MAPPER_FLAG_HOST` set), then the last step
+ * is not performed. As a result, this function call may use as much memory as
+ * the structure to copy itself.
  *
  * Note that the structure to copy must have a tree topology, i.e no field
  * should reference a parent node in the structure, or reference the same

--- a/include/aml/higher/mapper/visitor.h
+++ b/include/aml/higher/mapper/visitor.h
@@ -1,0 +1,271 @@
+/*******************************************************************************
+ * Copyright 2019 UChicago Argonne, LLC.
+ * (c.f. AUTHORS, LICENSE)
+ *
+ * This file is part of the AML project.
+ * For more info, see https://github.com/anlsys/aml
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+#ifndef AML_MAPPER_VISITOR_H
+#define AML_MAPPER_VISITOR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @addtogroup aml_mapper
+ *
+ * @{
+ **/
+
+/**
+ * The current state of a mapper visitor for the depth being visited.
+ * @see `aml_mapper_visitor`
+ */
+struct aml_mapper_visitor_state {
+	// Device pointer of the element currrently visited.
+	void *device_ptr;
+	// Byte copy of the element.
+	// This field is used to read fields pointer and the number of
+	// elements if the structure is actually an array of structures.
+	// The copy from device_ptr only happens when a parent descends its
+	// first child.
+	void *host_copy;
+	// Mapper of the element currrently visited.
+	struct aml_mapper *mapper;
+	// The field index in parent structure described by parent mapper.
+	// This field matches the field number in parent mapper.
+	size_t field_num;
+	// If the field currently visited is part of an array, this
+	// is the number of elements in this array. If not, it is 0.
+	size_t array_size;
+	// If the field currently visited is part of an array, this
+	// is the index of the current element in the array.
+	// The pointer of the array beginning is therefore:
+	// `device_ptr - mapper->size * array_num`.
+	size_t array_num;
+	// Parent states from parent data structures.
+	struct aml_mapper_visitor_state *next;
+};
+
+/**
+ * The visitor structure maintains the state of a visit of a data structure
+ * described by a hierarchy of mappers. The visited data structure, may have
+ * references to itself (cycles). However, cycles are not detected and might
+ * be leading to an infinite walk. The visited data structure is not modified
+ * by the visit and must not undergo structural modifications that affect the
+ * visit during the latter.
+ *
+ * For a given step/state of the visit, it is possible to query the pointer of
+ * the data being visited from inside the visited data structure with
+ * `aml_mapper_visitor_ptr()`. The latter can be the root structure
+ * at the creation of the visitor, a field inside the data structure when
+ * visiting fields, or an array of elements when visiting elements of a field
+ * which is an array of contiguous elements.
+ *
+ * It is also possible to query the size in byte of the visited field with
+ * `aml_mapper_visitor_size()`. This size accounts for the top level structure
+ * size and all its descendants.
+ *
+ * Visiting can be done toward a parent structure
+ * (`aml_mapper_visitor_parent()`), the first child field of the structure
+ * (`aml_mapper_visitor_first_field()`), sibling fields of the same parent
+ * (`aml_mapper_visitor_next_field()`) or even across array elements of an
+ * array field (`aml_mapper_visitor_next_array_element()`).
+ *
+ * @see `aml_mapper`
+ */
+struct aml_mapper_visitor {
+	// Stack of visited fields where head is the currently visited field
+	// and next elements are successive parents of the currently visited
+	// field.
+	struct aml_mapper_visitor_state *stack;
+	// dma engine from base_ptr area to host to dereference pointers.
+	struct aml_dma *dma;
+	// Memcpy operator of dma engine.
+	aml_dma_operator memcpy_op;
+};
+
+/**
+ * Create a visitor of a structure pointed by `ptr` and described by a `mapper`.
+ *
+ * If the structure pointer cannot be read from the host, it must be copied
+ * piece by piece during the visit, from the memory where it lives to the host
+ * memory with a `dma` engine and a `memcpy` operator. However, if the pointer
+ * is readable from the host, it is better to set these two arguments to
+ * NULL to improve performance.
+ *
+ * @param[out] out: A pointer where to store the newly allocated visitor.
+ * @param[in] ptr: The pointer to the structure to visit.
+ * @param[in] mapper: The description of the structure to visit.
+ * @param[in] dma: A dma engine to copy data from where ptr lives to the host.
+ * @param[in] memcpy_op: The suitable `memcpy` operator for the dma engine.
+ * @return AML_SUCCESS on sucess.
+ * @return -AML_ENOMEM on failure due to host memory allocation failure.
+ */
+int aml_mapper_visitor_create(struct aml_mapper_visitor **out,
+                              void *ptr,
+                              struct aml_mapper *mapper,
+                              struct aml_dma *dma,
+                              aml_dma_operator memcpy_op);
+
+/**
+ * Release memory allocated to a visitor.
+ * The visitor `it` cannot be used after this call.
+ *
+ * @param[in, out] it: The visitor to free.
+ * @return AML_SUCCESS on success.
+ * @return -AML_EINVAL if it is NULL.
+ */
+int aml_mapper_visitor_destroy(struct aml_mapper_visitor *it);
+
+/**
+ * Make a visitor from current visited state and limit it to visit only
+ * descendents of the current field.
+ *
+ * @param[in] it: The visitor to copy.
+ * @param[out] subtree_visitor: A pointer where to store the new visitor.
+ * @return AML_SUCCESS on success.
+ * @return -AML_ENOMEM if the new visitor could not be allocated.
+ */
+int aml_mapper_visitor_subtree(const struct aml_mapper_visitor *it,
+                               struct aml_mapper_visitor **subtree_visitor);
+
+/**
+ * Go to next array element of this field.
+ * After this function succeeds, the pointer returned by
+ * `aml_mapper_visitor_ptr()` will point to the next array element of the
+ * previously pointed element inside the array.
+ *
+ * @param[in, out] it: The visitor of the structure being visited.
+ * @return AML_SUCCESS on success.
+ * @return -AML_EDOM if the field is not an array or if their is no next
+ * element.
+ * @return -AML_EINVAL if the current element points to NULL.
+ */
+int aml_mapper_visitor_next_array_element(struct aml_mapper_visitor *it);
+
+/**
+ * Go to previous array element of this field.
+ * After this function succeeds, the pointer returned by
+ * `aml_mapper_visitor_ptr()` will point to the previous array element of the
+ * previously pointed element inside the array.
+ *
+ * @param[in, out] it: The visitor of the structure being visited.
+ * @return AML_SUCCESS on success.
+ * @return -AML_EDOM if the field is not an array or if their is no previous
+ * element.
+ * @return -AML_EINVAL if the current element points to NULL.
+ */
+int aml_mapper_visitor_prev_array_element(struct aml_mapper_visitor *it);
+
+/**
+ * Go to next sibling field of the current field from the parent structure.
+ *
+ * @param[in, out] it: The visitor of the structure being visited.
+ * @return AML_SUCCESS on success.
+ * @return -AML_EDOM if their is no next sibling field.
+ */
+int aml_mapper_visitor_next_field(struct aml_mapper_visitor *it);
+
+/**
+ * Go to previous sibling field of the current field from the parent structure.
+ *
+ * @param[in, out] it: The visitor of the structure being visited.
+ * @return AML_SUCCESS on success.
+ * @return -AML_EDOM if their is no previous sibling field.
+ */
+int aml_mapper_visitor_prev_field(struct aml_mapper_visitor *it);
+
+/**
+ * Go to first field of the current structure.
+ *
+ * This function might be expensive if the data being visited requires a dma
+ * engine to be read. Indeed, the new visited element will need to read
+ * the parent element to obtain its own pointer value and compute the number
+ * of elements it holds if it is an array.
+ *
+ * @param[in, out] it: The visitor of the structure being visited.
+ * @return AML_SUCCESS on success.
+ * @return -AML_EDOM if the current structure has no field to be descended.
+ * @return -AML_ENOMEM if the state of the new child field cannot be allocated.
+ * @return -AML_EINVAL if the currently visited element points to NULL.
+ */
+int aml_mapper_visitor_first_field(struct aml_mapper_visitor *it);
+
+/**
+ * Go to parent structure of the current structure.
+ *
+ * @param[in, out] it: The visitor of the structure being visited.
+ * @return AML_SUCCESS on success.
+ * @return -AML_EDOM if the current structure has no parent that has already
+ * been visited.
+ */
+int aml_mapper_visitor_parent(struct aml_mapper_visitor *it);
+
+/**
+ * Get a pointer to the currently visited element from the visited data
+ * structure.
+ *
+ * @param[in] it: The visitor of the structure being visited.
+ */
+void *aml_mapper_visitor_ptr(struct aml_mapper_visitor *it);
+
+/**
+ * Return whether the currently visited element is an array.
+ * This is equivalent to `it->stack->array_size > 1`.
+ *
+ * @param[in] it: The visitor of the structure being visited.
+ */
+int aml_mapper_visitor_is_array(struct aml_mapper_visitor *it);
+
+/**
+ * Return the length of the currently visited array element.
+ * If the element is not an array, the len will be 1.
+ * This is equivalent to `it->stack->array_size`.
+ *
+ * @param[in] it: The visitor of the structure being visited.
+ */
+size_t aml_mapper_visitor_array_len(struct aml_mapper_visitor *it);
+
+/**
+ * Compute the size of a structure based on a visitor.
+ * Visitor will skip nodes with mapper flag `AML_MAPPER_FLAG_SPLIT` set.
+ *
+ * @param[in] visitor: A visitor from where to compute size.
+ * @param[out] size: A pointer where to store size.
+ * @return AML_SUCCESS on success with size set.
+ * @return -AML_ENOMEM if allocation during the visit failed.
+ * @return -AML_EINVAL if NULL pointer node was found during the visit.
+ * @return Any error from the `visitor` dma engine.
+ */
+int aml_mapper_visitor_size(const struct aml_mapper_visitor *visitor,
+                            size_t *size);
+
+/**
+ * Check that the structure visited by two different visitors or equal
+ * bytewise except for indirections to child fields.
+ *
+ * @param[in] lhs: The visitor of the left hand side structure being
+ * compared.
+ * @param[in] rhs: The visitor of the right hand side structure being
+ * compared.
+ * @return 1 If structures match.
+ * @return 0 If structures don't match.
+ * @return -AML_ENOMEM if allocation during the visit failed.
+ * @return -AML_EINVAL if NULL pointer node was found during the visit.
+ * @return Any error from the visitors dma engine.
+ */
+int aml_mapper_visitor_match(const struct aml_mapper_visitor *lhs,
+                             const struct aml_mapper_visitor *rhs);
+/**
+ * @}
+ **/
+
+#ifdef __cplusplus
+}
+#endif
+#endif // AML_MAPPER_VISITOR_H

--- a/include/internal/utstack.h
+++ b/include/internal/utstack.h
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2018-2021, Troy D. Hanson   http://troydhanson.github.io/uthash/
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef UTSTACK_H
+#define UTSTACK_H
+
+#define UTSTACK_VERSION 2.3.0
+
+/*
+ * This file contains macros to manipulate a singly-linked list as a stack.
+ *
+ * To use utstack, your structure must have a "next" pointer.
+ *
+ * ----------------.EXAMPLE -------------------------
+ * struct item {
+ *      int id;
+ *      struct item *next;
+ * };
+ *
+ * struct item *stack = NULL;
+ *
+ * int main() {
+ *      int count;
+ *      struct item *tmp;
+ *      struct item *item = malloc(sizeof *item);
+ *      item->id = 42;
+ *      STACK_COUNT(stack, tmp, count); assert(count == 0);
+ *      STACK_PUSH(stack, item);
+ *      STACK_COUNT(stack, tmp, count); assert(count == 1);
+ *      STACK_POP(stack, item);
+ *      free(item);
+ *      STACK_COUNT(stack, tmp, count); assert(count == 0);
+ * }
+ * --------------------------------------------------
+ */
+
+#define STACK_TOP(head) (head)
+
+#define STACK_EMPTY(head) (!(head))
+
+#define STACK_PUSH(head,add)                                         \
+    STACK_PUSH2(head,add,next)
+
+#define STACK_PUSH2(head,add,next)                                   \
+do {                                                                 \
+  (add)->next = (head);                                              \
+  (head) = (add);                                                    \
+} while (0)
+
+#define STACK_POP(head,result)                                       \
+    STACK_POP2(head,result,next)
+
+#define STACK_POP2(head,result,next)                                 \
+do {                                                                 \
+  (result) = (head);                                                 \
+  (head) = (head)->next;                                             \
+} while (0)
+
+#define STACK_COUNT(head,el,counter)                                 \
+    STACK_COUNT2(head,el,counter,next)                               \
+
+#define STACK_COUNT2(head,el,counter,next)                           \
+do {                                                                 \
+  (counter) = 0;                                                     \
+  for ((el) = (head); el; (el) = (el)->next) { ++(counter); }        \
+} while (0)
+
+#endif /* UTSTACK_H */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,7 +45,10 @@ HIGHER_SOURCES = \
 		allocator/area.c \
 		allocator/buddy.c \
 		allocator/sized.c \
-		higher/mapper.c
+		higher/mapper.c \
+		higher/mapper-visitor.c \
+		higher/mapper-creator.c \
+		higher/mapper-deepcopy.c
 
 LIB_SOURCES = \
 	      $(AREA_SOURCES) \

--- a/src/higher/mapper-creator.c
+++ b/src/higher/mapper-creator.c
@@ -1,0 +1,388 @@
+/* copyright 2019 uchicago argonne, llc.
+ * (c.f. authors, license)
+ *
+ * this file is part of the aml project.
+ * for more info, see https://github.com/anlsys/aml
+ *
+ * spdx-license-identifier: bsd-3-clause
+ ******************************************************************************/
+
+#include "aml.h"
+
+#include "aml/higher/mapper.h"
+#include "aml/higher/mapper/creator.h"
+#include "aml/higher/mapper/visitor.h"
+
+#include "internal/utstack.h"
+
+#define PTR_OFF(ptr, sign, off) (void *)((intptr_t)(ptr)sign(intptr_t)(off))
+
+static int aml_mapper_creator_memcpy(struct aml_mapper_creator *c)
+{
+	struct aml_mapper_visitor_state *state = STACK_TOP(c->stack);
+	const size_t size = state->mapper->size * state->array_size;
+	void *src = state->device_ptr;
+	void *dst = state->host_copy;
+
+	// We always need to wait on this copy to complete in order to explore
+	// children or to finish the mapping.
+	if (c->dma_src_host != NULL) {
+		int err = aml_dma_copy_custom(c->dma_src_host,
+		                              (struct aml_layout *)dst,
+		                              (struct aml_layout *)src,
+		                              c->memcpy_src_host, (void *)size);
+		if (err != AML_SUCCESS)
+			return err;
+	} else
+		memcpy(dst, src, size);
+
+	c->offset += size;
+	return AML_SUCCESS;
+}
+
+static inline void **
+aml_mapper_creator_field_ptr(struct aml_mapper_visitor_state *field,
+                             struct aml_mapper_visitor_state *parent)
+{
+	return (void **)PTR_OFF(parent->host_copy, +,
+	                        parent->mapper->offsets[field->field_num]);
+}
+
+static inline int aml_mapper_creator_init_field(struct aml_mapper_creator *c,
+                                                const size_t num)
+{
+	struct aml_mapper_visitor_state *head = STACK_TOP(c->stack);
+	struct aml_mapper_visitor_state *parent = head->next;
+
+	head->mapper = parent->mapper->fields[num];
+
+	// If the new field is out of bounds of the allocated memory,
+	// and the field is not meant to be split, then there is a logic
+	// error in this file code.
+	assert(c->offset < c->size ||
+	       (c->offset == c->size &&
+	        (head->mapper->flags & AML_MAPPER_FLAG_SPLIT)));
+
+	head->field_num = num;
+	head->array_num = 0;
+	head->array_size = 1;
+	if (parent->mapper->num_elements != NULL &&
+	    parent->mapper->num_elements[num] != NULL)
+		head->array_size =
+		        parent->mapper->num_elements[num](parent->host_copy);
+
+	void **field_ptr = aml_mapper_creator_field_ptr(head, parent);
+	head->host_copy = PTR_OFF(c->host_memory, +, c->offset);
+	head->device_ptr = *field_ptr;
+	*field_ptr = PTR_OFF(c->device_memory, +, c->offset);
+
+	return AML_SUCCESS;
+}
+
+static int aml_mapper_creator_next_field(struct aml_mapper_creator *c)
+{
+	struct aml_mapper_visitor_state *head = STACK_TOP(c->stack);
+	struct aml_mapper_visitor_state *parent = head->next;
+
+	if (parent == NULL)
+		return -AML_EDOM;
+
+	size_t num = head->field_num + 1;
+	if (num >= parent->mapper->n_fields)
+		return -AML_EDOM;
+	return aml_mapper_creator_init_field(c, num);
+}
+
+static int aml_mapper_creator_first_field(struct aml_mapper_creator *c)
+{
+	const struct aml_mapper_visitor_state *parent = STACK_TOP(c->stack);
+	if (parent->mapper->n_fields == 0)
+		return -AML_EDOM;
+
+	// Create new state.
+	struct aml_mapper_visitor_state *state = malloc(sizeof *state);
+	if (state == NULL)
+		return -AML_ENOMEM;
+	STACK_PUSH(c->stack, state);
+	return aml_mapper_creator_init_field(c, 0);
+}
+
+static int aml_mapper_creator_parent(struct aml_mapper_creator *c)
+{
+	struct aml_mapper_visitor_state *head = c->stack;
+	if (head == NULL)
+		return -AML_EDOM;
+	STACK_POP(c->stack, head);
+	free(head);
+	return c->stack == NULL ? -AML_EDOM : AML_SUCCESS;
+}
+
+static int aml_mapper_creator_next_array_element(struct aml_mapper_creator *c)
+{
+	struct aml_mapper_visitor_state *head = STACK_TOP(c->stack);
+	if (head->array_num + 1 >= head->array_size)
+		return -AML_EDOM;
+	head->device_ptr = PTR_OFF(head->device_ptr, +, head->mapper->size);
+	head->host_copy = PTR_OFF(head->host_copy, +, head->mapper->size);
+	head->array_num++;
+	return AML_SUCCESS;
+}
+
+int aml_mapper_creator_connect(struct aml_mapper_creator *c, void *ptr)
+{
+	int err;
+	if (c == NULL || ptr == NULL ||
+	    !(c->stack->mapper->flags & AML_MAPPER_FLAG_SPLIT))
+		return -AML_EINVAL;
+
+	// Set pointer in parent structure to point to this new memory area
+	*aml_mapper_creator_field_ptr(c->stack, c->stack->next) = ptr;
+
+	// Move current creator to next field.
+next_field:
+	err = aml_mapper_creator_next_field(c);
+	if (err != -AML_EDOM)
+		return err;
+	err = aml_mapper_creator_parent(c);
+	if (err != AML_SUCCESS)
+		return err;
+	if (c->stack->mapper->n_fields == 0)
+		goto next_field;
+	err = aml_mapper_creator_next_array_element(c);
+	if (err == -AML_EDOM)
+		goto next_field;
+	if (err != AML_SUCCESS)
+		return err;
+	err = aml_mapper_creator_first_field(c);
+	if (err != -AML_EDOM)
+		return err;
+	goto next_field;
+}
+
+int aml_mapper_creator_branch(struct aml_mapper_creator **out,
+                              struct aml_mapper_creator *c,
+                              struct aml_area *area,
+                              struct aml_area_mmap_options *area_opts,
+                              struct aml_dma *dma_host_dst,
+                              aml_dma_operator memcpy_host_dst)
+{
+	int err;
+	if (out == NULL || c == NULL || area == NULL || dma_host_dst == NULL ||
+	    !(c->stack->mapper->flags & AML_MAPPER_FLAG_SPLIT))
+		return -AML_EINVAL;
+
+	// Get size to map.
+	size_t tot_size = 0;
+	if (c->stack->mapper->n_fields == 0)
+		tot_size = c->stack->mapper->size * c->stack->array_size;
+	else {
+		for (size_t i = 0; i < c->stack->array_size; i++) {
+			struct aml_mapper_visitor *visitor;
+			size_t size;
+			void *src_ptr = PTR_OFF(c->stack->device_ptr, +,
+			                        i * c->stack->mapper->size);
+			err = aml_mapper_visitor_create(&visitor, src_ptr,
+			                                c->stack->mapper,
+			                                c->dma_src_host,
+			                                c->memcpy_src_host);
+			if (err != AML_SUCCESS)
+				return err;
+			err = aml_mapper_visitor_size(visitor, &size);
+			aml_mapper_visitor_destroy(visitor);
+			if (err != AML_SUCCESS)
+				return err;
+			tot_size += size;
+		}
+	}
+	// Create a mapper creator for the field we just allocated.
+	err = aml_mapper_creator_create(out, c->stack->device_ptr, tot_size,
+	                                c->stack->mapper, area, area_opts,
+	                                c->dma_src_host, dma_host_dst,
+	                                c->memcpy_src_host, memcpy_host_dst);
+	if (err != AML_SUCCESS)
+		return err;
+	// Set correct array size.
+	(*out)->stack->array_size = c->stack->array_size;
+
+	// Set pointer in parent structure to point to this new memory area, and
+	// Move to next field.
+	return aml_mapper_creator_connect(c, (*out)->device_memory);
+}
+
+int aml_mapper_creator_next(struct aml_mapper_creator *c)
+{
+	int err;
+	if (c->stack == NULL)
+		return -AML_EDOM;
+	if (c->stack->mapper->flags & AML_MAPPER_FLAG_SPLIT &&
+	    c->stack->next != NULL)
+		return -AML_EINVAL;
+
+	// Copy to host.
+	// If the current state is an array element. The whole array has already
+	// been copied on first element.
+	if (c->stack->array_num == 0) {
+		err = aml_mapper_creator_memcpy(c);
+		if (err != AML_SUCCESS)
+			return err;
+	}
+
+	// Move to next field.
+first_field:
+	err = aml_mapper_creator_first_field(c);
+	if (err != -AML_EDOM)
+		return err;
+next_array_element:
+	if (c->stack->mapper->n_fields == 0)
+		goto next_field;
+	err = aml_mapper_creator_next_array_element(c);
+	if (err == AML_SUCCESS)
+		goto first_field;
+	if (err != -AML_EDOM)
+		return err;
+next_field:
+	err = aml_mapper_creator_next_field(c);
+	if (err != -AML_EDOM)
+		return err;
+	err = aml_mapper_creator_parent(c);
+	if (err != AML_SUCCESS)
+		return err;
+	goto next_array_element;
+}
+
+int aml_mapper_creator_create(struct aml_mapper_creator **out,
+                              void *src_ptr,
+                              size_t size,
+                              struct aml_mapper *mapper,
+                              struct aml_area *area,
+                              struct aml_area_mmap_options *area_opts,
+                              struct aml_dma *dma_src_host,
+                              struct aml_dma *dma_host_dst,
+                              aml_dma_operator memcpy_src_host,
+                              aml_dma_operator memcpy_host_dst)
+{
+	if (out == NULL || src_ptr == NULL || mapper == NULL)
+		return -AML_EINVAL;
+
+	// If flag host is set we don't build the device copy, only the host
+	// copy.
+	const int create_host = mapper->flags &
+	                        (AML_MAPPER_FLAG_HOST & ~AML_MAPPER_FLAG_SPLIT);
+	// If we build a device copy, these arguments must be set.
+	if (!create_host &&
+	    (area == NULL || dma_host_dst == NULL))
+		return -AML_EINVAL;
+
+	int err;
+	struct aml_mapper_visitor *visitor;
+
+	// Get the total size to map.
+	if (size == 0) {
+		err = aml_mapper_visitor_create(&visitor, src_ptr, mapper,
+		                                dma_src_host, memcpy_src_host);
+		if (err != AML_SUCCESS)
+			return err;
+		err = aml_mapper_visitor_size(visitor, &size);
+		aml_mapper_visitor_destroy(visitor);
+		if (err != AML_SUCCESS)
+			return err;
+	}
+
+	// Allocate buffer on host to contain the total size to map.
+	void *host_memory = malloc(size);
+	if (host_memory == NULL)
+		return -AML_ENOMEM;
+
+	// Initialize mapper creator with enough host memory to copy source
+	// structure.
+	err = -AML_ENOMEM;
+	struct aml_mapper_creator *c = malloc(sizeof(*c));
+	if (c == NULL)
+		goto err_with_host_memory;
+
+	c->size = size;
+	c->host_memory = host_memory;
+	c->offset = 0;
+	c->dma_src_host = dma_src_host;
+	c->memcpy_src_host = memcpy_src_host;
+	if (create_host) {
+		c->device_area = NULL;
+		c->dma_host_dst = NULL;
+		c->memcpy_host_dst = NULL;
+		c->device_memory = host_memory;
+	} else {
+		c->device_area = area;
+		c->dma_host_dst = dma_host_dst;
+		c->memcpy_host_dst = memcpy_host_dst;
+		// Allocate buffer in device to contain the total size to map.
+		c->device_memory = aml_area_mmap(area, size, area_opts);
+		if (c->device_memory == NULL) {
+			err = aml_errno;
+			goto err_with_creator;
+		}
+	}
+
+	struct aml_mapper_visitor_state *head = malloc(sizeof(*head));
+	if (head == NULL)
+		goto err_with_device_ptr;
+	// This the original pointer to copy, not the target device pointer.
+	head->device_ptr = src_ptr;
+	head->host_copy = c->host_memory;
+	head->mapper = mapper;
+	head->field_num = 0;
+	head->array_size = 1;
+	head->array_num = 0;
+	head->next = NULL;
+	c->stack = head;
+	*out = c;
+	return AML_SUCCESS;
+
+err_with_device_ptr:
+	if (!create_host)
+		aml_area_munmap(area, c->device_memory, size);
+err_with_creator:
+	free(c);
+err_with_host_memory:
+	free(host_memory);
+	return err;
+}
+
+int aml_mapper_creator_abort(struct aml_mapper_creator *c)
+{
+	if (c == NULL)
+		return -AML_EINVAL;
+
+	while (aml_mapper_creator_parent(c) == AML_SUCCESS)
+		;
+	if (c->device_area != NULL)
+		aml_area_munmap(c->device_area, c->device_memory, c->size);
+	free(c->host_memory);
+	free(c);
+	return AML_SUCCESS;
+}
+
+int aml_mapper_creator_finish(struct aml_mapper_creator *c,
+                              void **ptr,
+                              size_t *size)
+{
+	int err;
+	if (c->stack != NULL)
+		return -AML_EINVAL;
+	if (c->host_memory != c->device_memory) {
+		err = aml_dma_copy_custom(c->dma_host_dst, c->device_memory,
+		                          c->host_memory, c->memcpy_host_dst,
+		                          (void *)c->offset);
+		if (err != AML_SUCCESS)
+			return err;
+	}
+	if (ptr != NULL)
+		*ptr = c->device_memory;
+	if (size != NULL)
+		*size = c->offset;
+	while (aml_mapper_creator_parent(c) == AML_SUCCESS)
+		;
+	if (c->host_memory != c->device_memory)
+		free(c->host_memory);
+	free(c);
+	return AML_SUCCESS;
+}

--- a/src/higher/mapper-creator.c
+++ b/src/higher/mapper-creator.c
@@ -269,8 +269,7 @@ int aml_mapper_creator_create(struct aml_mapper_creator **out,
 	const int create_host = mapper->flags &
 	                        (AML_MAPPER_FLAG_HOST & ~AML_MAPPER_FLAG_SPLIT);
 	// If we build a device copy, these arguments must be set.
-	if (!create_host &&
-	    (area == NULL || dma_host_dst == NULL))
+	if (!create_host && (area == NULL || dma_host_dst == NULL))
 		return -AML_EINVAL;
 
 	int err;

--- a/src/higher/mapper-deepcopy.c
+++ b/src/higher/mapper-deepcopy.c
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright 2019 UChicago Argonne, LLC.
+ * (c.f. AUTHORS, LICENSE)
+ *
+ * This file is part of the AML project.
+ * For more info, see https://github.com/anlsys/aml
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+#include "aml.h"
+
+#include "aml/higher/mapper.h"
+#include "aml/higher/mapper/creator.h"
+#include "aml/higher/mapper/deepcopy.h"
+#include "aml/utils/inner-malloc.h"
+#define utarray_oom()                                                          \
+	do {                                                                   \
+		err = -AML_ENOMEM;                                             \
+		goto error;                                                    \
+	} while (0)
+#include "internal/utarray.h"
+
+void aml_mapped_ptr_destroy(void *ptr)
+{
+	struct aml_mapped_ptr *p = (struct aml_mapped_ptr *)ptr;
+	if (p->area != NULL)
+		(void)aml_area_munmap(p->area, p->ptr, p->size);
+	else
+		free(p->ptr);
+}
+
+static UT_icd aml_mapped_ptr_icd = {
+        .sz = sizeof(struct aml_mapped_ptr),
+        .init = NULL,
+        .copy = NULL,
+        .dtor = aml_mapped_ptr_destroy,
+};
+
+static void aml_mapper_creator_destroy(void *elt)
+{
+	struct aml_mapper_creator *c = *(struct aml_mapper_creator **)elt;
+	(void)aml_mapper_creator_abort(c);
+}
+
+static UT_icd creator_icd = {
+        .sz = sizeof(struct aml_mapper_creator *),
+        .init = NULL,
+        .copy = NULL,
+        .dtor = aml_mapper_creator_destroy,
+};
+
+void *aml_mapper_deepcopy(aml_mapped_ptrs *out,
+                          void *src_ptr,
+                          struct aml_mapper *mapper,
+                          struct aml_area *area,
+                          struct aml_area_mmap_options *area_opts,
+                          struct aml_dma *dma_src_host,
+                          struct aml_dma *dma_host_dst,
+                          aml_dma_operator memcpy_src_host,
+                          aml_dma_operator memcpy_host_dst)
+{
+	int err;
+	UT_array *ptrs = NULL;
+	UT_array crtrs;
+	struct aml_mapper_creator **crtr_ptr, *next = NULL;
+	struct aml_mapped_ptr ptr = {.ptr = NULL, .size = 0, .area = area};
+	struct aml_mapper_creator *crtr = NULL;
+
+	// Allocate array of creators spawned in branches.
+	utarray_init(&crtrs, &creator_icd);
+
+	// Allocate and initialize pointer array.
+	utarray_new(ptrs, &aml_mapped_ptr_icd);
+
+	// Allocate and initialize first constructor.
+	err = aml_mapper_creator_create(&crtr, src_ptr, 0, mapper, area,
+	                                area_opts, dma_src_host, dma_host_dst,
+	                                memcpy_src_host, memcpy_host_dst);
+	if (err != AML_SUCCESS)
+		goto error;
+
+iterate_creator:
+	err = aml_mapper_creator_next(crtr);
+	if (err == AML_SUCCESS)
+		goto iterate_creator;
+	if (err == -AML_EINVAL)
+		goto branch;
+	if (err == -AML_EDOM)
+		goto next_creator;
+	goto error;
+branch:
+	// Create branch.
+	err = aml_mapper_creator_branch(&next, crtr, area, area_opts,
+	                                dma_host_dst, memcpy_host_dst);
+	if (err != AML_SUCCESS && err != -AML_EDOM)
+		goto error;
+	// Push new creator to be in the stack of pending creators.
+	utarray_push_back(&crtrs, &next);
+	next = NULL; // Avoids double destruction on error.
+	if (err == AML_SUCCESS)
+		goto iterate_creator;
+	if (err == -AML_EINVAL)
+		goto branch;
+	if (err == -AML_EDOM)
+		goto next_creator;
+next_creator:
+	err = aml_mapper_creator_finish(crtr, &ptr.ptr, &ptr.size);
+	if (err != AML_SUCCESS)
+		goto error;
+	crtr = NULL; // Avoids double destruction on error.
+	utarray_push_back(ptrs, &ptr);
+	crtr_ptr = utarray_back(&crtrs);
+	if (crtr_ptr == NULL)
+		goto success;
+	crtrs.i--; // Pop back without calling destructor.
+	crtr = *crtr_ptr;
+	goto iterate_creator;
+success:
+	utarray_done(&crtrs);
+	*out = (aml_mapped_ptrs)ptrs;
+	return ((struct aml_mapped_ptr *)utarray_eltptr(ptrs, 0))->ptr;
+error:
+	if (crtr != NULL)
+		aml_mapper_creator_abort(crtr);
+	if (next != NULL)
+		aml_mapper_creator_abort(next);
+	if (ptrs != NULL)
+		utarray_free(ptrs);
+	utarray_done(&crtrs);
+	aml_errno = err;
+	return NULL;
+}
+
+int aml_mapper_deepfree(aml_mapped_ptrs data)
+{
+	UT_array *ptrs = (UT_array *)data;
+	struct aml_mapped_ptr *ptr;
+	int err;
+
+	if (ptrs == NULL)
+		return -AML_EINVAL;
+
+	while (1) {
+		ptr = utarray_back(ptrs);
+		if (ptr == NULL) {
+			utarray_free(ptrs);
+			return AML_SUCCESS;
+		}
+		err = aml_area_munmap(ptr->area, ptr->ptr, ptr->size);
+		if (err != AML_SUCCESS)
+			return err;
+		// Pop back without calling destructor.
+		// This avoids to call munmap twice on error.
+		ptrs->i--;
+	}
+}

--- a/src/higher/mapper-visitor.c
+++ b/src/higher/mapper-visitor.c
@@ -1,0 +1,470 @@
+/*******************************************************************************
+ * Copyright 2019 UChicago Argonne, LLC.
+ * (c.f. AUTHORS, LICENSE)
+ *
+ * This file is part of the AML project.
+ * For more info, see https://github.com/anlsys/aml
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+#include "aml.h"
+
+#include "aml/higher/mapper.h"
+#include "aml/higher/mapper/visitor.h"
+#include "aml/layout/dense.h"
+#include "aml/utils/inner-malloc.h"
+#include "aml/utils/queue.h"
+
+#include "internal/utstack.h"
+
+#define PTR_OFF(ptr, sign, off) (void *)((intptr_t)(ptr)sign(intptr_t)(off))
+
+// Create a new instance of visitor over ptr described by mapper where
+// dma and its memcpy operator copy from area where ptr is allocated to
+// host.
+int aml_mapper_visitor_create(struct aml_mapper_visitor **out,
+                              void *ptr,
+                              struct aml_mapper *mapper,
+                              struct aml_dma *dma,
+                              aml_dma_operator memcpy_op)
+{
+	if (out == NULL || ptr == NULL || mapper == NULL)
+		return -AML_EINVAL;
+
+	struct aml_mapper_visitor *it = malloc(sizeof(*it));
+	if (it == NULL)
+		return -AML_ENOMEM;
+	it->stack = NULL;
+	it->dma = dma;
+	it->memcpy_op = memcpy_op;
+
+	// Create first state representing the first iteration and push
+	// it to the state stack.
+	struct aml_mapper_visitor_state *head = malloc(sizeof(*head));
+	if (head == NULL) {
+		free(it);
+		return -AML_ENOMEM;
+	}
+	head->device_ptr = ptr;
+	head->host_copy = NULL;
+	head->mapper = mapper;
+	head->field_num = 0;
+	head->array_size = 1;
+	head->array_num = 0;
+	head->next = NULL;
+	STACK_PUSH(it->stack, head);
+
+	*out = it;
+	return AML_SUCCESS;
+}
+
+int aml_mapper_visitor_subtree(const struct aml_mapper_visitor *it,
+                               struct aml_mapper_visitor **subtree_visitor)
+{
+	// Cut the stack into the top host_copy.
+	// Since there is no parent in the stack, the visit is limited to
+	// child fields.
+	return aml_mapper_visitor_create(subtree_visitor, it->stack->device_ptr,
+	                                 it->stack->mapper, it->dma,
+	                                 it->memcpy_op);
+}
+
+int aml_mapper_visitor_destroy(struct aml_mapper_visitor *it)
+{
+	if (it == NULL)
+		return -AML_EINVAL;
+	while (aml_mapper_visitor_parent(it) == AML_SUCCESS)
+		;
+	free(it);
+	return AML_SUCCESS;
+}
+
+// Attempt to visit next element of currently visited array of elements.
+// If there is no more element to visit, -AML_EDOM is returned, else
+// visitor head state is updated to the state of its next array element.
+int aml_mapper_visitor_next_array_element(struct aml_mapper_visitor *it)
+{
+	struct aml_mapper_visitor_state *head = STACK_TOP(it->stack);
+	assert(head != NULL);
+	// Check if we reached array bounds
+	if ((head->array_num + 1) >= head->array_size)
+		return -AML_EDOM;
+	if (head->device_ptr == NULL)
+		return -AML_EINVAL;
+	// The device pointer of next array element is the same device pointer
+	// offseted by the element size.
+	head->device_ptr = PTR_OFF(head->device_ptr, +, head->mapper->size);
+	// Update index.
+	head->array_num++;
+	return AML_SUCCESS;
+}
+
+int aml_mapper_visitor_prev_array_element(struct aml_mapper_visitor *it)
+{
+	struct aml_mapper_visitor_state *head = STACK_TOP(it->stack);
+	assert(head != NULL);
+	if (head->array_num == 0)
+		return -AML_EDOM;
+	if (head->device_ptr == NULL)
+		return -AML_EINVAL;
+	head->device_ptr = PTR_OFF(head->device_ptr, -, head->mapper->size);
+	head->array_num--;
+	return AML_SUCCESS;
+}
+
+static int aml_mapper_visitor_field(struct aml_mapper_visitor *it,
+                                    const size_t num)
+{
+	struct aml_mapper_visitor_state *head = STACK_TOP(it->stack);
+	struct aml_mapper_visitor_state *parent = head->next;
+
+	// The new device pointer can be read in the parent byte copy.
+	// And it is the pointer at the offset of the next field offset.
+	head->device_ptr = *(void **)PTR_OFF(parent->host_copy, +,
+	                                     parent->mapper->offsets[num]);
+	// Update the other fields.
+	head->field_num = num;
+	head->mapper = parent->mapper->fields[num];
+	head->array_num = 0;
+	head->array_size = 1;
+	if (parent->mapper->num_elements != NULL &&
+	    parent->mapper->num_elements[num] != NULL)
+		head->array_size =
+		        parent->mapper->num_elements[num](parent->host_copy);
+
+	return AML_SUCCESS;
+}
+
+// Attempt to visit next field of the parent of the element of currently
+// visited. If there is no more sibling field to visit, -AML_EDOM is returned,
+// else visitor head state is updated to the state of its next sibling.
+int aml_mapper_visitor_next_field(struct aml_mapper_visitor *it)
+{
+	struct aml_mapper_visitor_state *head = STACK_TOP(it->stack);
+	assert(head != NULL);
+	struct aml_mapper_visitor_state *parent = head->next;
+
+	// If this has no parent, there is no next field in the parent.
+	if (parent == NULL)
+		return -AML_EDOM;
+
+	// Check bounds of the number of fields.
+	const size_t num = head->field_num + 1;
+	if (num >= parent->mapper->n_fields)
+		return -AML_EDOM;
+
+	return aml_mapper_visitor_field(it, num);
+}
+
+int aml_mapper_visitor_prev_field(struct aml_mapper_visitor *it)
+{
+	struct aml_mapper_visitor_state *head = STACK_TOP(it->stack);
+	assert(head != NULL);
+	if (head->next == NULL)
+		return -AML_EDOM;
+	if (head->field_num == 0)
+		return -AML_EDOM;
+
+	return aml_mapper_visitor_field(it, head->field_num - 1);
+}
+
+static int aml_mapper_visitor_byte_copy(struct aml_mapper_visitor *it)
+{
+	struct aml_mapper_visitor_state *state = STACK_TOP(it->stack);
+
+	if (it->dma != NULL) {
+		const size_t size = state->mapper->size;
+		void *element = malloc(size);
+		if (element == NULL)
+			return -AML_ENOMEM;
+
+		int err = aml_dma_copy_custom(
+		        it->dma, (struct aml_layout *)element,
+		        (struct aml_layout *)state->device_ptr, it->memcpy_op,
+		        (void *)size);
+		if (err != AML_SUCCESS) {
+			free(element);
+			return err;
+		}
+		if (state->host_copy != NULL)
+			free(state->host_copy);
+		state->host_copy = element;
+	} else
+		state->host_copy = state->device_ptr;
+	return AML_SUCCESS;
+}
+
+// Attempt to visit first child of the element of currently visited.
+// If there no child to visit, -AML_EDOM is returned, else a new state
+// representing first child element is pushed on top of the state stack.
+int aml_mapper_visitor_first_field(struct aml_mapper_visitor *it)
+{
+	struct aml_mapper_visitor_state *head = STACK_TOP(it->stack);
+	assert(head != NULL);
+
+	if (head->mapper->n_fields == 0)
+		return -AML_EDOM;
+	if (head->device_ptr == NULL)
+		return -AML_EINVAL;
+
+	// Byte copy current field structure to easily have access to number
+	// of fields and fields value later.
+	int err = aml_mapper_visitor_byte_copy(it);
+	if (err != AML_SUCCESS)
+		return err;
+
+	// Create the child state.
+	struct aml_mapper_visitor_state *next = malloc(sizeof *next);
+	if (next == NULL)
+		return -AML_ENOMEM;
+
+	// Device ptr is the pointer in current state host copy at the
+	// offset of the first field.
+	next->device_ptr =
+	        *(void **)PTR_OFF(head->host_copy, +, head->mapper->offsets[0]);
+	// Set next time this field is descended.
+	next->host_copy = NULL;
+	// Initialization for stack primitives
+	next->next = NULL;
+	// Mapper of new visited field.
+	next->mapper = head->mapper->fields[0];
+	// The new field is the first field.
+	next->field_num = 0;
+	// Start at first element.
+	next->array_num = 0;
+	// Default to not an array.
+	next->array_size = 1;
+	// Set array size if the state is an array.
+	if (head->mapper->num_elements != NULL &&
+	    head->mapper->num_elements[0] != NULL)
+		next->array_size =
+		        head->mapper->num_elements[0](head->host_copy);
+	// Push the new state at the top of the stack. This is the current
+	// state now.
+	STACK_PUSH(it->stack, next);
+
+	return AML_SUCCESS;
+}
+
+int aml_mapper_visitor_parent(struct aml_mapper_visitor *it)
+{
+	struct aml_mapper_visitor_state *head = it->stack;
+	if (head == NULL)
+		return -AML_EDOM;
+	STACK_POP(it->stack, head);
+	if (it->dma != NULL && head->host_copy != NULL)
+		free(head->host_copy);
+	free(head);
+	return it->stack == NULL ? -AML_EDOM : AML_SUCCESS;
+}
+
+void *aml_mapper_visitor_ptr(struct aml_mapper_visitor *it)
+{
+	return it->stack->device_ptr;
+}
+
+static size_t aml_mapper_size(struct aml_mapper_visitor *it)
+{
+	return it->stack->mapper->size * it->stack->array_size;
+}
+
+int aml_mapper_visitor_is_array(struct aml_mapper_visitor *it)
+{
+	return it->stack->array_size > 1;
+}
+
+size_t aml_mapper_visitor_array_len(struct aml_mapper_visitor *it)
+{
+	return it->stack->array_size;
+}
+
+int aml_mapper_visitor_size(const struct aml_mapper_visitor *visitor,
+                            size_t *size)
+{
+	struct aml_mapper_visitor *v;
+	size_t tot = 0;
+	int err;
+
+	err = aml_mapper_visitor_subtree(visitor, &v);
+	if (err != AML_SUCCESS)
+		return err;
+
+add_size:
+	tot += aml_mapper_size(v);
+first_field:
+	err = aml_mapper_visitor_first_field(v);
+	if (err == AML_SUCCESS)
+		goto check_split;
+	if (err != -AML_EDOM)
+		goto error;
+next_array_element:
+	if (v->stack->mapper->n_fields == 0)
+		goto next_field;
+	err = aml_mapper_visitor_next_array_element(v);
+	if (err == AML_SUCCESS)
+		goto first_field;
+	if (err != -AML_EDOM)
+		goto error;
+next_field:
+	err = aml_mapper_visitor_next_field(v);
+	if (err == AML_SUCCESS)
+		goto check_split;
+	if (err != -AML_EDOM)
+		goto error;
+	err = aml_mapper_visitor_parent(v);
+	if (err == AML_SUCCESS)
+		goto next_array_element;
+	if (err != -AML_EDOM)
+		goto error;
+	goto success;
+check_split:
+	// Skip nodes that will be split in a different allocation.
+	if (v->stack->mapper->flags & AML_MAPPER_FLAG_SPLIT)
+		goto next_field;
+	else
+		goto add_size;
+success:
+	aml_mapper_visitor_destroy(v);
+	*size = tot;
+	return AML_SUCCESS;
+error:
+	aml_mapper_visitor_destroy(v);
+	return err;
+}
+
+static int
+aml_mapper_visitor_state_match(const struct aml_mapper_visitor *visitor1,
+                               const struct aml_mapper_visitor *visitor2)
+{
+	const void *b1 = visitor1->stack->host_copy;
+	const void *b2 = visitor2->stack->host_copy;
+	const struct aml_mapper *m1 = visitor1->stack->mapper;
+	const struct aml_mapper *m2 = visitor2->stack->mapper;
+
+	// Check mappers match.
+	if (m1->size != m2->size)
+		return 0;
+	if (m1->n_fields != m2->n_fields)
+		return 0;
+	// If there is no field pointer, we just have to check if bytes match.
+	// This assumes that the visit will skip array elements after the
+	// first element if they have no descendants.
+	if (m1->n_fields == 0) {
+		const size_t size = m1->size * visitor1->stack->array_size;
+		return memcmp(b1, b2, size) == 0;
+	}
+	// Check fields are all at the same offsets.
+	if (memcmp(m1->offsets, m2->offsets,
+	           m1->n_fields * sizeof(*m1->offsets)))
+		return 0;
+	// Check bytes in between field pointers match.
+	// - First interval.
+	if (m1->offsets[0] != 0 && memcmp(b1, b2, m1->offsets[0]) != 0)
+		return 0;
+	// - First intervals between pointers.
+	for (size_t i = 1; i < m1->n_fields; i++) {
+		const size_t offset = m1->offsets[i - 1] + sizeof(void *);
+		const size_t size = m1->offsets[i] - offset;
+		if (size == 0)
+			continue;
+		if (memcmp(PTR_OFF(b1, +, offset), PTR_OFF(b2, +, offset),
+		           size) != 0)
+			return 0;
+	}
+	// - Last interval.
+	do {
+		const size_t offset =
+		        m1->offsets[m1->n_fields - 1] + sizeof(void *);
+		const size_t size = m1->size - offset;
+		if (size == 0)
+			break;
+		if (memcmp(PTR_OFF(b1, +, offset), PTR_OFF(b2, +, offset),
+		           size) != 0)
+			return 0;
+	} while (0);
+
+	// Everything matches.
+	return 1;
+}
+
+int aml_mapper_visitor_match(const struct aml_mapper_visitor *visitor1,
+                             const struct aml_mapper_visitor *visitor2)
+{
+	struct aml_mapper_visitor *v1, *v2;
+	int err1, err2;
+
+	err1 = aml_mapper_visitor_subtree(visitor1, &v1);
+	if (err1 != AML_SUCCESS)
+		return err1;
+	err1 = aml_mapper_visitor_subtree(visitor2, &v2);
+	if (err1 != AML_SUCCESS)
+		goto error_with_v1;
+
+first_field:
+	err1 = aml_mapper_visitor_first_field(v1);
+	err2 = aml_mapper_visitor_first_field(v2);
+	if (err1 != err2)
+		goto no_match;
+	if (err1 == AML_SUCCESS)
+		goto first_field;
+	if (err1 != -AML_EDOM)
+		goto error;
+next_array_element:
+	if (v1->stack->mapper->n_fields != v2->stack->mapper->n_fields)
+		goto no_match;
+	if (v1->stack->mapper->n_fields == 0) {
+		err1 = aml_mapper_visitor_byte_copy(v1);
+		if (err1 != AML_SUCCESS)
+			goto error;
+		err1 = aml_mapper_visitor_byte_copy(v2);
+		if (err1 != AML_SUCCESS)
+			goto error;
+		if (aml_mapper_visitor_state_match(v1, v2) == 0)
+			goto no_match;
+		goto next_field;
+	}
+	err1 = aml_mapper_visitor_next_array_element(v1);
+	err2 = aml_mapper_visitor_next_array_element(v2);
+	if (err1 != err2)
+		goto no_match;
+	if (err1 == AML_SUCCESS)
+		goto first_field;
+	if (err1 != -AML_EDOM)
+		goto error;
+next_field:
+	err1 = aml_mapper_visitor_next_field(v1);
+	err2 = aml_mapper_visitor_next_field(v2);
+	if (err1 != err2)
+		goto no_match;
+	if (err1 == AML_SUCCESS)
+		goto first_field;
+	if (err1 != -AML_EDOM)
+		goto error;
+	err1 = aml_mapper_visitor_parent(v1);
+	err2 = aml_mapper_visitor_parent(v2);
+	if (err1 != err2)
+		goto no_match;
+	if (err1 == -AML_EDOM)
+		goto success;
+	if (err1 != AML_SUCCESS)
+		goto error;
+	// If match fail, we stop the comparison and return 0.
+	if (aml_mapper_visitor_state_match(v1, v2) == 0)
+		goto no_match;
+	goto next_array_element;
+
+success:
+	aml_mapper_visitor_destroy(v2);
+	aml_mapper_visitor_destroy(v1);
+	return 1;
+error:
+	aml_mapper_visitor_destroy(v2);
+error_with_v1:
+	aml_mapper_visitor_destroy(v1);
+	return err1;
+no_match:
+	aml_mapper_visitor_destroy(v2);
+	aml_mapper_visitor_destroy(v1);
+	return 0;
+}

--- a/src/higher/mapper.c
+++ b/src/higher/mapper.c
@@ -11,11 +11,7 @@
 #include "aml.h"
 
 #include "aml/higher/mapper.h"
-#include "aml/layout/dense.h"
 #include "aml/utils/inner-malloc.h"
-#include "aml/utils/queue.h"
-
-#define PTR_OFF(ptr, sign, off) (void *)((intptr_t)(ptr)sign(intptr_t)(off))
 
 int aml_mapper_create(struct aml_mapper **out,
                       uint64_t flags,
@@ -83,420 +79,44 @@ void aml_mapper_destroy(struct aml_mapper **mapper)
 	}
 }
 
-#define get_num_elements(m, i, ptr)                                            \
-	((m->num_elements && m->num_elements[i]) ? m->num_elements[i](ptr) : 1)
-
-// Helper function to copy src into dst.
-static int aml_mapper_memcpy(void *dst,
-                             void *src,
-                             size_t size,
-                             struct aml_dma *dma,
-                             aml_dma_operator dma_op,
-                             void *dma_op_arg)
-{
-	int err;
-	struct aml_layout *_src, *_dst;
-	size_t dims = 1, stride = 0, pitch = size;
-
-	// Create layouts
-	err = aml_layout_dense_create(&_src, src, AML_LAYOUT_ORDER_FORTRAN,
-	                              size, 1, &dims, &stride, &pitch);
-	if (err != AML_SUCCESS)
-		return err;
-	err = aml_layout_dense_create(&_dst, dst, AML_LAYOUT_ORDER_FORTRAN,
-	                              size, 1, &dims, &stride, &pitch);
-	if (err != AML_SUCCESS)
-		goto out_with_src;
-
-	// Submit request
-	err = aml_dma_copy_custom(dma, _dst, _src, dma_op, dma_op_arg);
-
-	aml_layout_destroy(&_dst);
-out_with_src:
-	aml_layout_destroy(&_src);
-	return err;
-}
-
-ssize_t aml_mapper_mapped_size(struct aml_mapper *mapper,
-                               void *ptr,
-                               size_t num,
-                               struct aml_dma *dma,
-                               aml_dma_operator dma_op,
-                               void *dma_op_arg)
-{
-	int err;
-	size_t tot = 0;
-	char _ptr[mapper->size], *p;
-	void **src;
-
-	// Get a temporary host copy of ptr.
-	if (mapper->flags & AML_MAPPER_FLAG_SHALLOW || dma == NULL) {
-		p = ptr;
-	} else {
-		err = aml_mapper_memcpy(_ptr, ptr, sizeof(_ptr), dma, dma_op,
-		                        dma_op_arg);
-		if (err != AML_SUCCESS)
-			return (ssize_t)err;
-		p = _ptr;
-	}
-
-	if (!(mapper->flags & AML_MAPPER_FLAG_SHALLOW))
-		tot += mapper->size * num;
-
-	// Add size of each field of `ptr`.
-	for (size_t i = 0; i < mapper->n_fields; i++) {
-		// If flag AML_MAPPER_FLAG_SPLIT is set then do not
-		// count size.
-		if (mapper->fields[i]->flags & AML_MAPPER_FLAG_SPLIT)
-			continue;
-		size_t n = get_num_elements(mapper, i, ptr);
-		if (n == 0)
-			continue;
-		for (size_t j = 0; j < num; j++) {
-			src = PTR_OFF(p, +,
-			              mapper->size * j + mapper->offsets[i]);
-			if (*src == NULL)
-				continue;
-			tot += aml_mapper_mapped_size(mapper->fields[i], *src,
-			                              n, dma, dma_op,
-			                              dma_op_arg);
-		}
-	}
-	return tot;
-}
-
-static ssize_t mapper_mmap_recursive(struct aml_mapper *mapper,
-                                     void *dst,
-                                     void *src,
-                                     size_t num,
-                                     void *ptr,
-                                     struct aml_area *area,
-                                     struct aml_area_mmap_options *area_opts,
-                                     struct aml_dma *dma,
-                                     aml_dma_operator dma_op,
-                                     void *dma_op_arg)
-{
-	ssize_t err, off = 0;
-	const size_t size = mapper->size * num;
-
-	// Keep track of all indirections for final copy.
-	void *indirections[mapper->n_fields * num];
-	memset(indirections, 0, sizeof(indirections));
-
-	// For each field.
-	for (size_t j = 0; j < mapper->n_fields; j++) {
-		// Number of elements for each field.
-		size_t n = get_num_elements(mapper, j, src);
-		if (n == 0)
-			continue;
-
-		// For each array element.
-		for (size_t i = 0; i < num; i++) {
-			// src field pointer value.
-			void *src_ptr = *(void **)PTR_OFF(
-			        src, +, mapper->offsets[j] + i * mapper->size);
-			if (src_ptr == NULL)
-				continue;
-			// If split flag is set then we need to allocate new
-			// space.
-			if (mapper->fields[j]->flags & AML_MAPPER_FLAG_SPLIT) {
-				err = aml_mapper_mmap(
-				        mapper->fields[j],
-				        &indirections[j * num + i], src_ptr, n,
-				        area, area_opts, dma, dma_op,
-				        dma_op_arg);
-				if (err < 0)
-					goto err_mmap;
-			}
-			// Else we recurse on field.
-			else if (mapper->fields[j]->flags &
-			         AML_MAPPER_FLAG_SHALLOW) {
-				void *dst_ptr = *(void **)PTR_OFF(
-				        dst, +,
-				        mapper->offsets[j] + i * mapper->size);
-				if (dst_ptr == NULL)
-					continue;
-				err = mapper_mmap_recursive(
-				        mapper->fields[j], dst_ptr, src_ptr, n,
-				        PTR_OFF(ptr, +, off), area, area_opts,
-				        dma, dma_op, dma_op_arg);
-				if (err < 0)
-					goto err_mmap;
-				indirections[j * num + i] = dst_ptr;
-				off += err;
-			} else {
-				err = mapper_mmap_recursive(
-				        mapper->fields[j], PTR_OFF(ptr, +, off),
-				        src_ptr, n,
-				        PTR_OFF(ptr, +,
-				                off + n * mapper->fields[j]
-				                                        ->size),
-				        area, area_opts, dma, dma_op,
-				        dma_op_arg);
-				if (err < 0)
-					goto err_mmap;
-				indirections[j * num + i] =
-				        PTR_OFF(ptr, +, off);
-				off += err;
-			}
-		}
-	}
-
-	// Recursion on child fields is over.
-	// Now we can copy pointers and struct content.
-	if (mapper->flags & AML_MAPPER_FLAG_SHALLOW) {
-		memcpy(dst, src, size);
-		for (size_t i = 0; i < num; i++)
-			for (size_t j = 0; j < mapper->n_fields; j++)
-				*(void **)PTR_OFF(dst, +,
-				                  mapper->size * i +
-				                          mapper->offsets[j]) =
-				        indirections[j * num + i];
-	} else {
-		char *local_copy = malloc(size);
-		if (local_copy == NULL) {
-			err = -AML_ENOMEM;
-			goto err_mmap;
-		}
-		// Copy struct
-		memcpy(local_copy, src, size);
-		// Copy indirections
-		for (size_t i = 0; i < num; i++)
-			for (size_t j = 0; j < mapper->n_fields; j++)
-				*(void **)PTR_OFF(local_copy, +,
-				                  mapper->size * i +
-				                          mapper->offsets[j]) =
-				        indirections[j * num + i];
-		// Move buffer to device.
-		err = aml_mapper_memcpy(dst, local_copy, size, dma, dma_op,
-		                        dma_op_arg);
-		free(local_copy);
-		if (err != AML_SUCCESS)
-			goto err_mmap;
-	}
-
-	// Everything went fine! Return advances in pointer.
-	return off + ((mapper->flags & AML_MAPPER_FLAG_SHALLOW) ? 0 : size);
-
-err_mmap:
-	for (size_t j = 0; j < mapper->n_fields; j++)
-		if (mapper->fields[j]->flags & AML_MAPPER_FLAG_SPLIT) {
-			size_t n = get_num_elements(mapper, j, src);
-			for (size_t i = 0; i < num; i++)
-				if (indirections[j * num + i] != NULL) {
-					void *src_ptr = *(void **)PTR_OFF(
-					        src, +,
-					        mapper->offsets[j] +
-					                i * mapper->size);
-					aml_mapper_munmap(
-					        mapper->fields[j],
-					        indirections[j * num + i], n,
-					        src_ptr, area, dma, dma_op,
-					        dma_op_arg);
-				}
-		}
-	return err;
-}
-
-int aml_mapper_mmap(struct aml_mapper *mapper,
-                    void *dst,
-                    void *src,
-                    size_t num,
-                    struct aml_area *area,
-                    struct aml_area_mmap_options *area_opts,
-                    struct aml_dma *dma,
-                    aml_dma_operator dma_op,
-                    void *dma_op_arg)
-{
-	if (src == NULL || dst == NULL || mapper == NULL || area == NULL ||
-	    dma == NULL)
-		return -AML_EINVAL;
-
-	ssize_t err;
-	void *out;
-
-	// Alloc pointer
-	ssize_t size =
-	        aml_mapper_mapped_size(mapper, src, num, NULL, NULL, NULL);
-	if (size < 0)
-		return size;
-	out = aml_area_mmap(area, size, area_opts);
-	if (out == NULL)
-		return -AML_ENOMEM;
-
-	// Map recursively in allocated space.
-	if (mapper->flags & AML_MAPPER_FLAG_SHALLOW)
-		err = mapper_mmap_recursive(mapper, dst, src, num, out, area,
-		                            area_opts, dma, dma_op, dma_op_arg);
-	else
-		err = mapper_mmap_recursive(mapper, out, src, num,
-		                            PTR_OFF(out, +, mapper->size * num),
-		                            area, area_opts, dma, dma_op,
-		                            dma_op_arg);
-	if (err < 0) {
-		aml_area_munmap(area, &out, size);
-		return (int)err;
-	}
-
-	if (!(mapper->flags & AML_MAPPER_FLAG_SHALLOW))
-		*(void **)dst = out;
-	return AML_SUCCESS;
-}
-
-int aml_mapper_copy(struct aml_mapper *mapper,
-                    void *dst,
-                    void *src,
-                    size_t num,
-                    struct aml_dma *dma,
-                    aml_dma_operator dma_op,
-                    void *dma_op_arg)
-{
-	if (src == dst)
-		return AML_SUCCESS;
-
-	int err;
-	void **dst_field;
-	void *src_field; // Cannot dereference device pointer
-	size_t size = mapper->size * num;
-	void *local_dst = malloc(size);
-
-	if (local_dst == NULL)
-		return -AML_ENOMEM;
-
-	// Copy into local buffer.
-	if (mapper->flags & AML_MAPPER_FLAG_SHALLOW) {
-		memcpy(local_dst, src, size);
-	} else {
-		err = aml_mapper_memcpy(local_dst, src, size, dma, dma_op,
-		                        dma_op_arg);
-		if (err != AML_SUCCESS)
-			goto err_with_local_dst;
-	}
-
-	// Copy/Save dst original indirections into local buffer
-	for (size_t i = 0; i < num; i++)
-		for (size_t j = 0; j < mapper->n_fields; j++)
-			*(void **)PTR_OFF(local_dst, +,
-			                  i * mapper->size +
-			                          mapper->offsets[j]) =
-			        *(void **)PTR_OFF(dst, +,
-			                          i * mapper->size +
-			                                  mapper->offsets[j]);
-
-	// Copy local buffer into dst
-	memcpy(dst, local_dst, size);
-
-	// Recurse for each pointer
-	for (size_t j = 0; j < mapper->n_fields; j++) {
-		size_t n = get_num_elements(mapper, j, local_dst);
-		if (n == 0)
-			continue;
-		for (size_t i = 0; i < num; i++) {
-
-			dst_field = PTR_OFF(
-			        dst, +, i * mapper->size + mapper->offsets[j]);
-			src_field = PTR_OFF(
-			        src, +, i * mapper->size + mapper->offsets[j]);
-			// Get device pointer at position src_field and copy it
-			// in the same variable.
-			if (mapper->flags & AML_MAPPER_FLAG_SHALLOW)
-				src_field = *(void **)src_field;
-			else {
-				err = aml_mapper_memcpy(&src_field, src_field,
-				                        sizeof(src_field), dma,
-				                        dma_op, dma_op_arg);
-				if (err != AML_SUCCESS)
-					goto err_with_local_dst;
-			}
-
-			if (src_field == NULL)
-				continue;
-
-			err = aml_mapper_copy(mapper->fields[j], *dst_field,
-			                      src_field, n, dma, dma_op,
-			                      dma_op_arg);
-			if (err != AML_SUCCESS)
-				goto err_with_local_dst;
-		}
-	}
-
-	free(local_dst);
-	return AML_SUCCESS;
-err_with_local_dst:
-	free(local_dst);
-	return err;
-}
-
-static ssize_t mapper_munmap_recursive(struct aml_mapper *mapper,
-                                       void *ptr,
-                                       size_t num,
-                                       void *src,
-                                       struct aml_area *area,
-                                       struct aml_dma *dma,
-                                       aml_dma_operator dma_op,
-                                       void *dma_op_arg)
-{
-	size_t s = 0;
-	void *field_ptr, *src_ptr;
-	ssize_t err;
-
-	// Recurse to unmap every children first.
-	for (size_t i = 0; i < mapper->n_fields; i++) {
-		size_t n = get_num_elements(mapper, i, src);
-		for (size_t j = 0; j < num; j++) {
-			src_ptr = *(void **)PTR_OFF(
-			        src, +, mapper->size * j + mapper->offsets[i]);
-			// Get pointer to child field.
-			err = aml_mapper_memcpy(
-			        &field_ptr,
-			        PTR_OFF(ptr, +,
-			                mapper->size * j + mapper->offsets[i]),
-			        sizeof(field_ptr), dma, dma_op, dma_op_arg);
-			if (err < 0)
-				return err;
-			if (field_ptr == NULL)
-				continue;
-
-			if (mapper->fields[0]->flags & AML_MAPPER_FLAG_SPLIT) {
-				err = aml_mapper_munmap(mapper->fields[i],
-				                        field_ptr, n, src_ptr,
-				                        area, dma, dma_op,
-				                        dma_op_arg);
-			} else {
-				err = mapper_munmap_recursive(
-				        mapper->fields[i], field_ptr, n,
-				        src_ptr, area, dma, dma_op, dma_op_arg);
-			}
-
-			if (err < 0)
-				return err;
-			s += err;
-		}
-	}
-
-	// If this structure was not split, then return size of it
-	// non-split children.
-	return mapper->size * num + s;
-}
-
-ssize_t aml_mapper_munmap(struct aml_mapper *mapper,
-                          void *ptr,
-                          size_t num,
-                          void *src,
-                          struct aml_area *area,
-                          struct aml_dma *dma,
-                          aml_dma_operator dma_op,
-                          void *dma_op_arg)
-{
-	ssize_t s = mapper_munmap_recursive(mapper, ptr, num, src, area, dma,
-	                                    dma_op, dma_op_arg);
-	if (s <= 0)
-		return s;
-
-	if (mapper->flags & AML_MAPPER_FLAG_SHALLOW)
-		aml_area_munmap(area, PTR_OFF(ptr, +, mapper->offsets[0]),
-		                s - num * mapper->size);
-	else
-		aml_area_munmap(area, ptr, s);
-	return AML_SUCCESS;
-}
+aml_final_mapper_decl(aml_char_mapper, 0, char);
+aml_final_mapper_decl(aml_short_mapper, 0, short);
+aml_final_mapper_decl(aml_int_mapper, 0, int);
+aml_final_mapper_decl(aml_long_mapper, 0, long);
+aml_final_mapper_decl(aml_long_long_mapper, 0, long long);
+aml_final_mapper_decl(aml_uchar_mapper, 0, unsigned char);
+aml_final_mapper_decl(aml_uint_mapper, 0, unsigned int);
+aml_final_mapper_decl(aml_ulong_mapper, 0, unsigned long);
+aml_final_mapper_decl(aml_ulong_long_mapper, 0, unsigned long long);
+aml_final_mapper_decl(aml_float_mapper, 0, float);
+aml_final_mapper_decl(aml_double_mapper, 0, double);
+aml_final_mapper_decl(aml_long_double_mapper, 0, long double);
+aml_final_mapper_decl(aml_ptr_mapper, 0, void *);
+aml_final_mapper_decl(aml_char_split_mapper, AML_MAPPER_FLAG_SPLIT, char);
+aml_final_mapper_decl(aml_short_split_mapper, AML_MAPPER_FLAG_SPLIT, short);
+aml_final_mapper_decl(aml_int_split_mapper, AML_MAPPER_FLAG_SPLIT, int);
+aml_final_mapper_decl(aml_long_split_mapper, AML_MAPPER_FLAG_SPLIT, long);
+aml_final_mapper_decl(aml_long_long_split_mapper,
+                      AML_MAPPER_FLAG_SPLIT,
+                      long long);
+aml_final_mapper_decl(aml_uchar_split_mapper,
+                      AML_MAPPER_FLAG_SPLIT,
+                      unsigned char);
+aml_final_mapper_decl(aml_ushort_split_mapper,
+                      AML_MAPPER_FLAG_SPLIT,
+                      unsigned short);
+aml_final_mapper_decl(aml_uint_split_mapper,
+                      AML_MAPPER_FLAG_SPLIT,
+                      unsigned int);
+aml_final_mapper_decl(aml_ulong_split_mapper,
+                      AML_MAPPER_FLAG_SPLIT,
+                      unsigned long);
+aml_final_mapper_decl(aml_ulong_long_split_mapper,
+                      AML_MAPPER_FLAG_SPLIT,
+                      unsigned long long);
+aml_final_mapper_decl(aml_float_split_mapper, AML_MAPPER_FLAG_SPLIT, float);
+aml_final_mapper_decl(aml_double_split_mapper, AML_MAPPER_FLAG_SPLIT, double);
+aml_final_mapper_decl(aml_long_double_split_mapper,
+                      AML_MAPPER_FLAG_SPLIT,
+                      long double);
+aml_final_mapper_decl(aml_ptr_split_mapper, AML_MAPPER_FLAG_SPLIT, void *);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -88,6 +88,9 @@ DMA_TESTS = dma/test_linux
 
 HIGHER_TESTS = \
 	higher/test_mapper \
+	higher/test_mapper-visitor \
+	higher/test_mapper-creator \
+	higher/test_mapper-deepcopy \
 	allocator/test_area \
 	allocator/test_buddy \
 	allocator/test_sized

--- a/tests/higher/test_mapper-creator.c
+++ b/tests/higher/test_mapper-creator.c
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright 2019 UChicago Argonne, LLC.
+ * (c.f. AUTHORS, LICENSE)
+ *
+ * This file is part of the AML project.
+ * For more info, see https://github.com/anlsys/aml
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+#include "aml.h"
+
+// Mapper includes
+#include "aml/higher/mapper.h"
+#include "aml/higher/mapper/creator.h"
+#include "aml/higher/mapper/visitor.h"
+
+// Mapper args (linux)
+#include "aml/area/linux.h"
+#include "aml/dma/linux.h"
+
+struct A {
+	size_t dummy;
+};
+aml_final_mapper_decl(struct_A_mapper, 0, struct A);
+
+struct B {
+	struct A *first;
+	struct A *second;
+};
+aml_mapper_decl(struct_B_mapper,
+                AML_MAPPER_FLAG_SPLIT,
+                struct B,
+                first,
+                &struct_A_mapper,
+                second,
+                &struct_A_mapper);
+
+struct C {
+	size_t n;
+	struct B *first;
+};
+
+aml_mapper_decl(struct_C_mapper,
+                AML_MAPPER_FLAG_HOST,
+                struct C,
+                first,
+                n,
+                &struct_B_mapper);
+
+struct C *c;
+
+void init()
+{
+	const size_t n = 2;
+	c = AML_INNER_MALLOC_EXTRA(n, struct B, n * sizeof(struct A), struct C);
+	c->n = n;
+	c->first = AML_INNER_MALLOC_GET_ARRAY(c, struct B, struct C);
+
+	for (size_t i = 0; i < n; i++) {
+		struct A *a = (struct A *)((size_t)AML_INNER_MALLOC_GET_EXTRA(
+		                                   c, n, struct B, struct C) +
+		                           i * sizeof(struct A));
+		a->dummy = i;
+		c->first[i].first = a;
+		c->first[i].second = a;
+	}
+}
+
+int is_equal(struct C *other)
+{
+	// Scalars have the same value
+	if (c->n != other->n)
+		return 0;
+	// Pointers have not been litterally copied.
+	assert(c->first != other->first);
+
+	// Arrays have the same number of elements.
+	// Otherwise there will be a memory error on valgrind check.
+	for (size_t i = 0; i < c->n; i++) {
+		// Pointers have not been litterally copied.
+		assert(c->first[i].first != other->first[i].first);
+		assert(c->first[i].second != other->first[i].second);
+		// Scalars have the same value
+		if (c->first[i].first->dummy != other->first[i].first->dummy)
+			return 0;
+		if (c->first[i].second->dummy != other->first[i].second->dummy)
+			return 0;
+	}
+	return 1;
+}
+
+void teardown()
+{
+	free(c);
+}
+
+void test_mapper_creator()
+{
+	struct aml_mapper_creator *creator, *branch;
+	void *root, *split;
+	size_t sizeof_root, sizeof_split;
+	struct aml_mapper_visitor *lhs, *rhs;
+
+	// Initialize creator
+	assert(aml_mapper_creator_create(&creator, (void *)c, 0,
+	                                 &struct_C_mapper, NULL, NULL, NULL,
+	                                 NULL, NULL, NULL) == AML_SUCCESS);
+
+	// Copy root.
+	assert(aml_mapper_creator_next(creator) == AML_SUCCESS);
+	// The next field has SPLIT flag on.
+	assert(aml_mapper_creator_next(creator) == -AML_EINVAL);
+
+	// Construct first field.
+	assert(aml_mapper_creator_branch(&branch, creator, &aml_area_linux,
+	                                 NULL, aml_dma_linux,
+	                                 aml_dma_linux_memcpy_op) == -AML_EDOM);
+	// Copy array.
+	assert(aml_mapper_creator_next(branch) == AML_SUCCESS);
+	// Array element 0, first field.
+	assert(aml_mapper_creator_next(branch) == AML_SUCCESS);
+	// Array element 0, second field.
+	assert(aml_mapper_creator_next(branch) == AML_SUCCESS);
+	// Array element 1, first field.
+	assert(aml_mapper_creator_next(branch) == AML_SUCCESS);
+	// Array element 1, second field.
+	// This is the last thing to copy.
+	assert(aml_mapper_creator_next(branch) == -AML_EDOM);
+	assert(aml_mapper_creator_finish(branch, &split, &sizeof_split) ==
+	       AML_SUCCESS);
+	assert(sizeof_split ==
+	       c->n * (sizeof(struct B) + sizeof(struct A) + sizeof(struct A)));
+
+	// Back to root copy.
+	// There should be nothing left to copy.
+	assert(aml_mapper_creator_next(creator) == -AML_EDOM);
+	// Done.
+	assert(aml_mapper_creator_finish(creator, &root, &sizeof_root) ==
+	       AML_SUCCESS);
+	assert(sizeof_root == sizeof(struct C));
+
+	// Check the copied structure and original structure are identical.
+	// is_equal() test adds to the aml_mapper_visitor_match() test that it
+	// makes sure fields pointer are different, i.e they have not been
+	// literally copied.
+	assert(is_equal(root));
+	aml_mapper_visitor_create(&lhs, (void *)c, &struct_C_mapper,
+	                          aml_dma_linux, aml_dma_linux_memcpy_op);
+	aml_mapper_visitor_create(&rhs, (void *)root, &struct_C_mapper, NULL,
+	                          NULL);
+	assert(aml_mapper_visitor_match(lhs, rhs) == 1);
+	// Try to change original structure to break the match.
+	c->first[0].first->dummy = 32456;
+	assert(aml_mapper_visitor_match(lhs, rhs) == 0);
+	c->first[0].first->dummy = 0;
+	c->n = 1;
+	assert(aml_mapper_visitor_match(lhs, rhs) == 0);
+	// Restore to the same structure.
+	c->n = 2;
+	assert(aml_mapper_visitor_match(lhs, rhs) == 1);
+
+	// Cleanup
+	aml_mapper_visitor_destroy(lhs);
+	aml_mapper_visitor_destroy(rhs);
+	free(root);
+	aml_area_munmap(&aml_area_linux, split, sizeof_split);
+}
+
+int main(int argc, char **argv)
+{
+	// Init
+	aml_init(&argc, &argv);
+	init();
+
+	// Tests
+	test_mapper_creator();
+
+	// Cleanup
+	teardown();
+	aml_finalize();
+	return 0;
+}

--- a/tests/higher/test_mapper-deepcopy.c
+++ b/tests/higher/test_mapper-deepcopy.c
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright 2019 UChicago Argonne, LLC.
+ * (c.f. AUTHORS, LICENSE)
+ *
+ * This file is part of the AML project.
+ * For more info, see https://github.com/anlsys/aml
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+#include "aml.h"
+
+// Mapper includes
+#include "aml/higher/mapper.h"
+#include "aml/higher/mapper/deepcopy.h"
+#include "aml/higher/mapper/visitor.h"
+
+// Mapper args (linux)
+#include "aml/area/linux.h"
+#include "aml/dma/linux.h"
+
+// Mapper args (cuda)
+#if AML_HAVE_BACKEND_CUDA
+#include "aml/area/cuda.h"
+#include "aml/dma/cuda.h"
+#endif
+
+// Mapper args (cuda)
+#if AML_HAVE_BACKEND_HIP
+#include "aml/area/hip.h"
+#include "aml/dma/hip.h"
+#endif
+
+// Structures and mappers declaration. ----------------------------------------
+
+struct A {
+	size_t val;
+};
+aml_final_mapper_decl(struct_A_mapper, 0, struct A);
+
+struct B {
+	int dummy_int;
+	double dummy_double;
+	struct A *a;
+};
+aml_mapper_decl(
+        struct_B_mapper, AML_MAPPER_FLAG_SPLIT, struct B, a, &struct_A_mapper);
+
+struct C {
+	size_t n;
+	struct B *b;
+};
+aml_mapper_decl(struct_C_mapper, 0, struct C, b, n, &struct_B_mapper);
+
+// Initialization and teardown. -----------------------------------------------
+
+struct C *c;
+
+void init()
+{
+	const size_t n = 8;
+	c = AML_INNER_MALLOC_EXTRA(n, struct B, n * sizeof(struct A), struct C);
+	c->n = n;
+	c->b = AML_INNER_MALLOC_GET_ARRAY(c, struct B, struct C);
+
+	for (size_t i = 0; i < n; i++) {
+		struct A *a = (struct A *)((size_t)AML_INNER_MALLOC_GET_EXTRA(
+		                                   c, n, struct B, struct C) +
+		                           i * sizeof(struct A));
+		a->val = i;
+		c->b[i].a = a;
+		c->b[i].dummy_double = i;
+		c->b[i].dummy_int = -i;
+	}
+}
+
+void teardown()
+{
+	free(c);
+}
+
+// Tests ----------------------------------------------------------------------
+
+void test_mapper(struct aml_mapper *mapper,
+                 struct aml_area *area,
+                 struct aml_area_mmap_options *area_opts,
+                 struct aml_dma *dma_dst_host,
+                 struct aml_dma *dma_host_dst,
+                 aml_dma_operator memcpy_dst_host,
+                 aml_dma_operator memcpy_host_dst)
+{
+	aml_mapped_ptrs data;
+	void *copy;
+	struct aml_mapper_visitor *lhs_vis, *rhs_vis;
+
+	// Make copy.
+	copy = aml_mapper_deepcopy(&data, (void *)c, mapper, area, area_opts,
+	                           NULL, dma_host_dst, NULL, memcpy_host_dst);
+	assert(copy != NULL);
+
+	// Compare.
+	assert(aml_mapper_visitor_create(&lhs_vis, (void *)c, mapper, NULL,
+	                                 NULL) == AML_SUCCESS);
+	assert(aml_mapper_visitor_create(&rhs_vis, copy, mapper, dma_dst_host,
+	                                 memcpy_dst_host) == AML_SUCCESS);
+	assert(aml_mapper_visitor_match(lhs_vis, rhs_vis) == 1);
+
+	// Cleanup
+	aml_mapper_visitor_destroy(lhs_vis);
+	aml_mapper_visitor_destroy(rhs_vis);
+	assert(aml_mapper_deepfree(data) == AML_SUCCESS);
+}
+
+//- Main ----------------------------------------------------------------------
+
+int main(int argc, char **argv)
+{
+	// Init
+	aml_init(&argc, &argv);
+	init();
+
+	// Tests
+	test_mapper(&struct_C_mapper, &aml_area_linux, NULL, aml_dma_linux,
+	            aml_dma_linux, aml_dma_linux_memcpy_op,
+	            aml_dma_linux_memcpy_op);
+
+#if AML_HAVE_BACKEND_CUDA
+	if (aml_support_backends(AML_BACKEND_CUDA)) {
+		test_mapper(&struct_C_mapper, &aml_area_cuda, NULL,
+		            &aml_dma_cuda, &aml_dma_cuda,
+		            aml_dma_cuda_memcpy_op, aml_dma_cuda_memcpy_op);
+	}
+#endif
+#if AML_HAVE_BACKEND_HIP
+	if (aml_support_backends(AML_BACKEND_HIP)) {
+		test_mapper(&struct_C_mapper, &aml_area_hip, NULL, &aml_dma_hip,
+		            &aml_dma_hip, aml_dma_hip_memcpy_op,
+		            aml_dma_hip_memcpy_op);
+	}
+#endif
+	// Cleanup
+	teardown();
+	aml_finalize();
+	return 0;
+}

--- a/tests/higher/test_mapper-visitor.c
+++ b/tests/higher/test_mapper-visitor.c
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright 2019 UChicago Argonne, LLC.
+ * (c.f. AUTHORS, LICENSE)
+ *
+ * This file is part of the AML project.
+ * For more info, see https://github.com/anlsys/aml
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+#include "aml.h"
+
+// Mapper includes
+#include "aml/higher/mapper.h"
+#include "aml/higher/mapper/visitor.h"
+
+// Mapper args (linux)
+#include "aml/dma/linux.h"
+
+struct A {
+	size_t unused;
+};
+aml_final_mapper_decl(struct_A_mapper, 0, struct A);
+
+struct B {
+	struct A *first;
+	struct A *second;
+};
+aml_mapper_decl(struct_B_mapper,
+                0,
+                struct B,
+                first,
+                &struct_A_mapper,
+                second,
+                &struct_A_mapper);
+
+struct C {
+	size_t n;
+	struct B *first;
+};
+
+aml_mapper_decl(struct_C_mapper, 0, struct C, first, n, &struct_B_mapper);
+
+struct C *c;
+
+void init()
+{
+	const size_t n = 2;
+	c = AML_INNER_MALLOC_EXTRA(n, struct B, n * sizeof(struct A), struct C);
+	c->n = n;
+	c->first = AML_INNER_MALLOC_GET_ARRAY(c, struct B, struct C);
+
+	for (size_t i = 0; i < n; i++) {
+		struct A *a = (struct A *)((size_t)AML_INNER_MALLOC_GET_EXTRA(
+		                                   c, n, struct B, struct C) +
+		                           i * sizeof(struct A));
+		c->first[i].first = a;
+		c->first[i].second = a;
+	}
+}
+
+void teardown()
+{
+	free(c);
+}
+
+void test_mapper_visitor()
+{
+	struct aml_mapper_visitor *it;
+
+	assert(aml_mapper_visitor_create(
+	               &it, (void *)c, &struct_C_mapper, aml_dma_linux,
+	               aml_dma_linux_memcpy_op) == AML_SUCCESS);
+
+	// Root
+	assert(aml_mapper_visitor_ptr(it) == c);
+	assert(aml_mapper_visitor_next_field(it) == -AML_EDOM);
+	assert(aml_mapper_visitor_prev_field(it) == -AML_EDOM);
+	assert(aml_mapper_visitor_next_array_element(it) == -AML_EDOM);
+	assert(aml_mapper_visitor_prev_array_element(it) == -AML_EDOM);
+	assert(!aml_mapper_visitor_is_array(it));
+	assert(aml_mapper_visitor_first_field(it) == AML_SUCCESS);
+
+	// field of 2 struct B
+	assert(aml_mapper_visitor_ptr(it) == c->first);
+	assert(aml_mapper_visitor_array_len(it) == c->n);
+	assert(aml_mapper_visitor_next_field(it) == -AML_EDOM);
+	assert(aml_mapper_visitor_prev_field(it) == -AML_EDOM);
+	assert(aml_mapper_visitor_prev_array_element(it) == -AML_EDOM);
+	assert(aml_mapper_visitor_next_array_element(it) == AML_SUCCESS);
+	assert(aml_mapper_visitor_next_array_element(it) == -AML_EDOM);
+	assert(aml_mapper_visitor_ptr(it) == &(c->first[1]));
+	assert(aml_mapper_visitor_parent(it) == AML_SUCCESS);
+	assert(aml_mapper_visitor_ptr(it) == c);
+	assert(aml_mapper_visitor_first_field(it) == AML_SUCCESS);
+	assert(aml_mapper_visitor_first_field(it) == AML_SUCCESS);
+
+	// Struct A: first field of struct B.
+	assert(aml_mapper_visitor_ptr(it) == c->first[0].first);
+	assert(!aml_mapper_visitor_is_array(it));
+	assert(aml_mapper_visitor_first_field(it) == -AML_EDOM);
+	assert(aml_mapper_visitor_prev_field(it) == -AML_EDOM);
+	assert(aml_mapper_visitor_next_array_element(it) == -AML_EDOM);
+	assert(aml_mapper_visitor_prev_array_element(it) == -AML_EDOM);
+	assert(aml_mapper_visitor_next_field(it) == AML_SUCCESS);
+
+	// Struct A: second field of struct B.
+	assert(aml_mapper_visitor_ptr(it) == c->first[0].second);
+	assert(!aml_mapper_visitor_is_array(it));
+	assert(aml_mapper_visitor_first_field(it) == -AML_EDOM);
+	assert(aml_mapper_visitor_next_field(it) == -AML_EDOM);
+
+	// Cleanup
+	aml_mapper_visitor_destroy(it);
+}
+
+void test_mapper_visitor_match()
+{
+	struct aml_mapper_visitor *lhs, *rhs;
+
+	aml_mapper_visitor_create(&lhs, (void *)c, &struct_C_mapper,
+	                          aml_dma_linux, aml_dma_linux_memcpy_op);
+	aml_mapper_visitor_create(&rhs, (void *)c, &struct_C_mapper,
+	                          aml_dma_linux, aml_dma_linux_memcpy_op);
+
+	// Test equality.
+	assert(aml_mapper_visitor_match(lhs, rhs) == 1);
+
+	// Cleanup
+	aml_mapper_visitor_destroy(lhs);
+	aml_mapper_visitor_destroy(rhs);
+}
+
+void test_mapper_visitor_size()
+{
+	size_t size;
+	const size_t real_size =
+	        sizeof(struct C) +
+	        c->n * (sizeof(struct B) + sizeof(struct A) + sizeof(struct A));
+	struct aml_mapper_visitor *it;
+
+	aml_mapper_visitor_create(&it, (void *)c, &struct_C_mapper,
+	                          aml_dma_linux, aml_dma_linux_memcpy_op);
+	assert(aml_mapper_visitor_size(it, &size) == AML_SUCCESS);
+	assert(size == real_size);
+	aml_mapper_visitor_destroy(it);
+}
+
+int main(int argc, char **argv)
+{
+	// Init
+	aml_init(&argc, &argv);
+	init();
+
+	// Tests
+	test_mapper_visitor();
+	test_mapper_visitor_size();
+	test_mapper_visitor_match();
+
+	// Cleanup
+	teardown();
+	aml_finalize();
+	return 0;
+}

--- a/tests/higher/test_mapper.c
+++ b/tests/higher/test_mapper.c
@@ -13,26 +13,7 @@
 // Mapper includes
 #include "aml/higher/mapper.h"
 
-// Mapper args (linux)
-#include "aml/area/linux.h"
-#include "aml/dma/linux.h"
-
-// Mapper args (cuda)
-#if AML_HAVE_BACKEND_CUDA
-#include "aml/area/cuda.h"
-#include "aml/dma/cuda.h"
-#endif
-
-// Mapper args (cuda)
-#if AML_HAVE_BACKEND_HIP
-#include "aml/area/hip.h"
-#include "aml/dma/hip.h"
-#endif
-
-const size_t n = 8;
-
-//- Struct C Declaration ------------------------------------------------------
-
+// Largest working mapper decl
 struct BigStruct {
 	unsigned long *a0;
 	unsigned na0;
@@ -58,48 +39,44 @@ struct BigStruct {
 	unsigned na10;
 };
 
-aml_final_mapper_decl(ulong_mapper, 0, unsigned long);
-
-// Largest working mapper decl
 aml_mapper_decl(BigStruct_mapper,
                 0,
                 struct BigStruct,
                 a0,
                 na0,
-                &ulong_mapper,
+                &aml_ulong_mapper,
                 a1,
                 na1,
-                &ulong_mapper,
+                &aml_ulong_mapper,
                 a2,
                 na2,
-                &ulong_mapper,
+                &aml_ulong_mapper,
                 a3,
                 na3,
-                &ulong_mapper,
+                &aml_ulong_mapper,
                 a4,
                 na4,
-                &ulong_mapper,
+                &aml_ulong_mapper,
                 a5,
                 na5,
-                &ulong_mapper,
+                &aml_ulong_mapper,
                 a6,
                 na6,
-                &ulong_mapper,
+                &aml_ulong_mapper,
                 a7,
                 na7,
-                &ulong_mapper,
+                &aml_ulong_mapper,
                 a8,
                 na8,
-                &ulong_mapper,
+                &aml_ulong_mapper,
                 a9,
                 na9,
-                &ulong_mapper,
+                &aml_ulong_mapper,
                 a10,
                 na10,
-                &ulong_mapper);
+                &aml_ulong_mapper);
 
-//- Default mapper test ------------------------------------------------------
-
+// Other mapped struct.
 struct A {
 	size_t val;
 };
@@ -119,201 +96,7 @@ struct C {
 };
 aml_mapper_decl(struct_C_mapper, 0, struct C, b, n, &struct_B_mapper);
 
-void init_struct(struct C **_c)
+int main(void)
 {
-	*_c = AML_INNER_MALLOC_EXTRA(n, struct B, n * sizeof(struct A),
-	                             struct C);
-	(*_c)->n = n;
-	(*_c)->b = AML_INNER_MALLOC_GET_ARRAY((*_c), struct B, struct C);
-
-	for (size_t i = 0; i < n; i++) {
-		struct A *a =
-		        (struct A *)((size_t)AML_INNER_MALLOC_GET_EXTRA(
-		                             (*_c), n, struct B, struct C) +
-		                     i * sizeof(struct A));
-		a->val = i;
-		(*_c)->b[i].a = a;
-		(*_c)->b[i].dummy_double = i;
-		(*_c)->b[i].dummy_int = -i;
-	}
-}
-
-int eq_struct(struct C *a, struct C *b)
-{
-	if (a->n != b->n)
-		return 0;
-
-	for (size_t i = 0; i < a->n; i++) {
-		if (a->b[i].dummy_double != b->b[i].dummy_double)
-			return 0;
-		if (a->b[i].dummy_int != b->b[i].dummy_int)
-			return 0;
-		if (a->b[i].a->val != b->b[i].a->val)
-			return 0;
-	}
-	return 1;
-}
-
-void test_mapper(struct C *c)
-{
-	// Linux check
-	struct C *host_c;
-	assert(aml_mapper_mmap(&struct_C_mapper, &host_c, c, 1, &aml_area_linux,
-	                       NULL, aml_dma_linux, aml_dma_linux_copy_1D,
-	                       NULL) == AML_SUCCESS);
-	assert(eq_struct(c, host_c));
-
-	// Cuda check
-#if AML_HAVE_BACKEND_CUDA
-	if (aml_support_backends(AML_BACKEND_CUDA)) {
-		struct C *device_c;
-		/* Copy c to cuda device */
-		assert(aml_mapper_mmap(&struct_C_mapper, &device_c, c, 1,
-		                       &aml_area_cuda, NULL, &aml_dma_cuda,
-		                       aml_dma_cuda_copy_1D,
-		                       NULL) == AML_SUCCESS);
-
-		// Change _c to be different from c.
-		c->b[0].a->val = 4565467567;
-
-		/* Copy back __c into modified _c */
-		assert(aml_mapper_copy(&struct_C_mapper, c, device_c, 1,
-		                       &aml_dma_cuda, aml_dma_cuda_copy_1D,
-		                       NULL) == AML_SUCCESS);
-		assert(eq_struct(c, host_c));
-
-		aml_mapper_munmap(&struct_C_mapper, device_c, 1, c,
-		                  &aml_area_cuda, &aml_dma_cuda,
-		                  aml_dma_cuda_copy_1D, NULL);
-	}
-#endif
-#if AML_HAVE_BACKEND_HIP
-	if (aml_support_backends(AML_BACKEND_HIP)) {
-		struct C *device_c;
-		/* Copy c to hip device */
-		assert(aml_mapper_mmap(&struct_C_mapper, &device_c, c, 1,
-		                       &aml_area_hip, NULL, &aml_dma_hip,
-		                       aml_dma_hip_copy_1D,
-		                       NULL) == AML_SUCCESS);
-
-		// Change _c to be different from c.
-		c->b[0].a->val = 4565467567;
-
-		/* Copy back __c into modified _c */
-		assert(aml_mapper_copy(&struct_C_mapper, c, device_c, 1,
-		                       &aml_dma_hip, aml_dma_hip_copy_1D,
-		                       NULL) == AML_SUCCESS);
-		assert(eq_struct(c, host_c));
-
-		aml_mapper_munmap(&struct_C_mapper, device_c, 1, c,
-		                  &aml_area_hip, &aml_dma_hip,
-		                  aml_dma_hip_copy_1D, NULL);
-	}
-#endif
-	aml_mapper_munmap(&struct_C_mapper, host_c, 1, c, &aml_area_linux,
-	                  aml_dma_linux, aml_dma_linux_copy_1D, NULL);
-}
-
-//- Shallow mapper test ------------------------------------------------------
-
-aml_mapper_decl(shallow_B_mapper,
-                AML_MAPPER_FLAG_SHALLOW,
-                struct B,
-                a,
-                &struct_A_mapper);
-
-aml_mapper_decl(shallow_C_mapper,
-                AML_MAPPER_FLAG_SHALLOW,
-                struct C,
-                b,
-                n,
-                &shallow_B_mapper);
-
-void test_shallow_mapper(struct C *c)
-{
-	struct B host_b[n];
-	struct C host_c;
-	host_c.b = host_b;
-
-	// Linux check
-	assert(aml_mapper_mmap(&shallow_C_mapper, &host_c, c, 1,
-	                       &aml_area_linux, NULL, aml_dma_linux,
-	                       aml_dma_linux_copy_1D, NULL) == AML_SUCCESS);
-	assert(eq_struct(c, &host_c));
-
-	// Cuda check
-#if AML_HAVE_BACKEND_CUDA
-	if (aml_support_backends(AML_BACKEND_CUDA)) {
-		struct B device_b[n];
-		struct C device_c;
-		device_c.b = device_b;
-
-		/* Copy c to cuda device */
-		assert(aml_mapper_mmap(&shallow_C_mapper, &device_c, c, 1,
-		                       &aml_area_cuda, NULL, &aml_dma_cuda,
-		                       aml_dma_cuda_copy_1D,
-		                       NULL) == AML_SUCCESS);
-
-		// Change _c to be different from c.
-		c->b[0].a->val = 4565467567;
-
-		/* Copy back __c into modified _c */
-		assert(aml_mapper_copy(&shallow_C_mapper, c, &device_c, 1,
-		                       &aml_dma_cuda, aml_dma_cuda_copy_1D,
-		                       NULL) == AML_SUCCESS);
-		assert(eq_struct(c, &host_c));
-
-		aml_mapper_munmap(&shallow_C_mapper, &device_c, 1, c,
-		                  &aml_area_cuda, &aml_dma_cuda,
-		                  aml_dma_cuda_copy_1D, NULL);
-	}
-#endif
-	// Hip check
-#if AML_HAVE_BACKEND_HIP
-	if (aml_support_backends(AML_BACKEND_HIP)) {
-		struct B device_b[n];
-		struct C device_c;
-		device_c.b = device_b;
-
-		/* Copy c to hip device */
-		assert(aml_mapper_mmap(&shallow_C_mapper, &device_c, c, 1,
-		                       &aml_area_hip, NULL, &aml_dma_hip,
-		                       aml_dma_hip_copy_1D,
-		                       NULL) == AML_SUCCESS);
-
-		// Change _c to be different from c.
-		c->b[0].a->val = 4565467567;
-
-		/* Copy back __c into modified _c */
-		assert(aml_mapper_copy(&shallow_C_mapper, c, &device_c, 1,
-		                       &aml_dma_hip, aml_dma_hip_copy_1D,
-		                       NULL) == AML_SUCCESS);
-		assert(eq_struct(c, &host_c));
-
-		aml_mapper_munmap(&shallow_C_mapper, &device_c, 1, c,
-		                  &aml_area_hip, &aml_dma_hip,
-		                  aml_dma_hip_copy_1D, NULL);
-	}
-#endif
-	aml_mapper_munmap(&shallow_C_mapper, &host_c, 1, c, &aml_area_linux,
-	                  aml_dma_linux, aml_dma_linux_copy_1D, NULL);
-}
-
-//- Application Data Initialization -------------------------------------------
-
-int main(int argc, char **argv)
-{
-	struct C *c;
-
-	// Init
-	aml_init(&argc, &argv);
-	init_struct(&c);
-
-	// Tests
-	test_mapper(c);
-	test_shallow_mapper(c);
-	// Cleanup
-	free(c);
-	aml_finalize();
 	return 0;
 }


### PR DESCRIPTION
This PR lays the foundation for deepcopying and data replication.

The PR keeps the same mapper description but decouples the abstraction for 1. visiting a structure, 2. copying it element by element and 3. Implementing an end to end deepcopy in a single function call. Following these changes, tutorials have been updated to the right deepcopy function calls.

1) The visitor abstraction provides the methods to move around in a data structure, query pointers, compute the total size of a deep structure or even byte-wise comparison of such structures. The abstraction is defined in the header `aml/include/higher/mapper/visitor.h`, implemented in `src/higher/mapper-visitor.c` and tested in `tests/higher/test_mapper-visitor.c`.

2) The creator abstraction provides methods to perform an iterative depth-first walk of a structure and copy it element by element. This abstraction also allows to split the allocation of the target data structure on some milestone points designated by a flag in the structure "mapper" while allowing to connect such pieces "en-route". The abstraction is defined in the header `aml/include/higher/mapper/creator.h`, implemented in `src/higher/mapper-creator.c` and tested in `tests/higher/test_mapper-creator.c`.

3) The deepcopy abstraction uses the creator and visitor to implement an end-to-end copy of a deep data structure from any area to any area. The deepcopy abstraction is defined in the header `aml/include/higher/mapper/deepcopy.h`, implemented in `src/higher/mapper-deepcopy.c` and tested in `tests/higher/test_mapper-deepcopy.c`.
