### PR TITLE
Pass OpenMP options to the linker undisturbed

### DIFF
--- a/benchmarks/Makefile.am
+++ b/benchmarks/Makefile.am
@@ -1,7 +1,7 @@
 AM_COLOR_TESTS = yes
 
 AM_CFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include -I$(top_srcdir)/excit/src $(PTHREAD_CFLAGS) $(OPENMP_CFLAGS)
-AM_LDFLAGS = ../src/libaml.la $(top_builddir)/excit/src/libexcit.la $(PTHREAD_LIBS) $(OPENMP_CFLAGS)
+AM_LDFLAGS = ../src/libaml.la $(top_builddir)/excit/src/libexcit.la $(PTHREAD_LIBS) $(OPENMP_LIBS)
 
 if HAVE_CUDA
 # LIBS is used instead of AM_LDFLAGS on purpose

--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,18 @@ else
    HAVE_OPENMP="1"
 fi
 
+# protext OPENMP_CFLAGS from libtool: libtool filters linker flags it doesn't
+# know about, which can easily happen with these ones
+if test -n "$OPENMP_CFLAGS"; then
+    OPENMP_LIBS=" $OPENMP_CFLAGS"
+    # m4 quoting rules make the sed regexp a nightmare
+    # use quadrigraph to write this rule: s/[ ][ ]*\([^ ]\)/ -XCClinker \1/g
+    OPENMP_LIBS="`AS_ECHO_N("$OPENMP_LIBS") | sed 's/@<:@ @:>@@<:@ @:>@*\(@<:@^ @:>@\)/ -XCClinker \1/g'`"
+else
+    OPENMP_LIBS=""
+fi
+AC_SUBST(OPENMP_LIBS)
+
 # NUMA support
 ##############
 
@@ -436,6 +448,7 @@ OPENMP:
 
 Active:  $HAVE_OPENMP
 CFLAGS:  $OPENMP_CFLAGS
+LDFLAGS: $OPENMP_LIBS
 
 HWLOC:
 ======

--- a/doc/tutorials/Makefile.am
+++ b/doc/tutorials/Makefile.am
@@ -1,7 +1,7 @@
 AM_COLOR_TESTS = yes
 
 AM_CFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include -I$(top_srcdir)/excit/src $(PTHREAD_CFLAGS)  $(OPENMP_CFLAGS)
-AM_LDFLAGS = $(top_builddir)/src/libaml.la $(top_builddir)/excit/src/libexcit.la $(PTHREAD_LIBS) $(OPENMP_CFLAGS)
+AM_LDFLAGS = $(top_builddir)/src/libaml.la $(top_builddir)/excit/src/libexcit.la $(PTHREAD_LIBS) $(OPENMP_LIBS)
 
 if HAVE_CUDA
 # LIBS is used instead of AM_LDFLAGS on purpose

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,6 @@
 SUFFIXES=.c .cu
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include -I$(top_srcdir)/excit/src $(PTHREAD_CFLAGS) $(OPENMP_CFLAGS)
-# We need to prefix each option from OPENMP_CFLAGS with a libtool-specific
-# -XCClinker flag to prevent libtool from filtering the option out when
-#  invoking the linking stage.  This is necessary for the
-#  "-fopenmp -fiopenmp -fopenmp-targets=spir64" flags used with Intel ZE.
-AM_LDFLAGS = $(PTHREAD_LIBS) `if test -n '$(OPENMP_CFLAGS)'; then echo -n '-XCClinker '; echo $(OPENMP_CFLAGS) | sed 's/[ ][ ]*\([^ ]\)/ -XCClinker \1/g'; fi`
+AM_LDFLAGS = $(PTHREAD_LIBS) $(OPENMP_LIBS)
 noinst_LTLIBRARIES=
 
 #############################################

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,10 @@
 SUFFIXES=.c .cu
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include -I$(top_srcdir)/excit/src $(PTHREAD_CFLAGS) $(OPENMP_CFLAGS)
-AM_LDFLAGS = $(PTHREAD_LIBS) $(OPENMP_CFLAGS)
+# We need to prefix each option from OPENMP_CFLAGS with a libtool-specific
+# -XCClinker flag to prevent libtool from filtering the option out when
+#  invoking the linking stage.  This is necessary for the
+#  "-fopenmp -fiopenmp -fopenmp-targets=spir64" flags used with Intel ZE.
+AM_LDFLAGS = $(PTHREAD_LIBS) `if test -n '$(OPENMP_CFLAGS)'; then echo -n '-XCClinker '; echo $(OPENMP_CFLAGS) | sed 's/[ ][ ]*\([^ ]\)/ -XCClinker \1/g'; fi`
 noinst_LTLIBRARIES=
 
 #############################################

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,7 +2,7 @@
 AM_COLOR_TESTS = yes
 
 AM_CFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include -I$(top_srcdir)/excit/src $(PTHREAD_CFLAGS) $(OPENMP_CFLAGS)
-AM_LDFLAGS = ../src/libaml.la $(top_builddir)/excit/src/libexcit.la $(PTHREAD_LIBS) $(OPENMP_CFLAGS)
+AM_LDFLAGS = ../src/libaml.la $(top_builddir)/excit/src/libexcit.la $(PTHREAD_LIBS) $(OPENMP_LIBS)
 
 if HAVE_CUDA
 LIBS += $(CUDA_LIBS)


### PR DESCRIPTION
Follow-up to #228. Turns out that libtool filters unknown options out when linking a shared library; and for Intel ZE we need to pass those options undisturbed. There is a way to do it, by prefixing each such options with a libtool-specific `-XCClinker`. I had to whip up an ugly shell script as `Makefile.am` didn't like me using things like make's `patsubst`...