### PR TITLE
Fix races

### DIFF
--- a/include/aml/dma/linux.h
+++ b/include/aml/dma/linux.h
@@ -125,8 +125,8 @@ struct aml_dma_linux_request {
 	int task_out;
 	// Request flags
 	int flags;
-	// Flags lock
-	pthread_mutex_t flags_lock;
+	// Request lock
+	pthread_mutex_t lock;
 };
 
 /**

--- a/include/aml/dma/linux.h
+++ b/include/aml/dma/linux.h
@@ -125,6 +125,8 @@ struct aml_dma_linux_request {
 	int task_out;
 	// Request flags
 	int flags;
+	// Flags lock
+	pthread_mutex_t flags_lock;
 };
 
 /**

--- a/src/dma/linux.c
+++ b/src/dma/linux.c
@@ -18,10 +18,10 @@ void aml_dma_linux_exec_request(struct aml_task_in *input,
 {
 	struct aml_dma_linux_task_in *in =
 	        (struct aml_dma_linux_task_in *)input;
+	pthread_mutex_lock(&in->req->lock);
 	*(int *)output = in->op(in->dst, in->src, in->op_arg);
-	pthread_mutex_lock(&in->req->flags_lock);
 	in->req->flags = in->req->flags | AML_DMA_LINUX_REQUEST_FLAGS_DONE;
-	pthread_mutex_unlock(&in->req->flags_lock);
+	pthread_mutex_unlock(&in->req->lock);
 }
 
 int aml_dma_linux_request_create(struct aml_dma_data *data,
@@ -59,7 +59,7 @@ int aml_dma_linux_request_create(struct aml_dma_data *data,
 		r->flags = 0;
 	} else
 		r->flags = AML_DMA_LINUX_REQUEST_FLAGS_OWNED;
-	if (pthread_mutex_init(&r->flags_lock, NULL)) {
+	if (pthread_mutex_init(&r->lock, NULL)) {
 		perror("pthread_mutex_init");
 		free(r);
 		return -AML_FAILURE;
@@ -73,18 +73,17 @@ int aml_dma_linux_request_wait(struct aml_dma_data *dma,
 {
 	struct aml_sched *sched = (struct aml_sched *)dma;
 	struct aml_dma_linux_request *r = *(struct aml_dma_linux_request **)req;
-	int flags;
 
-	pthread_mutex_lock(&r->flags_lock);
-	flags = r->flags;
-	pthread_mutex_unlock(&r->flags_lock);
-	if (!(flags & AML_DMA_LINUX_REQUEST_FLAGS_DONE)) {
-		int err = aml_sched_wait_task(sched, &r->task);
-		if (err != AML_SUCCESS)
-			return err;
-	}
+	int err = aml_sched_wait_task(sched, &r->task);
+	if (err != AML_SUCCESS)
+		return err;
+
+	pthread_mutex_lock(&r->lock);
+	assert(r->flags & AML_DMA_LINUX_REQUEST_FLAGS_DONE);
 	int out = r->task_out;
-	pthread_mutex_destroy(&r->flags_lock);
+	pthread_mutex_unlock(&r->lock);
+
+	pthread_mutex_destroy(&r->lock);
 	free(r);
 	*req = NULL;
 	return out;
@@ -99,12 +98,12 @@ int aml_dma_linux_barrier(struct aml_dma_data *dma)
 
 	while (t != NULL) {
 		input = (struct aml_dma_linux_task_in *)t->in;
+		pthread_mutex_lock(&input->req->lock);
 		out = input->req->task_out;
-		pthread_mutex_lock(&input->req->flags_lock);
 		flags = input->req->flags;
-		pthread_mutex_unlock(&input->req->flags_lock);
+		pthread_mutex_unlock(&input->req->lock);
 		if (flags & AML_DMA_LINUX_REQUEST_FLAGS_OWNED) {
-			pthread_mutex_destroy(&input->req->flags_lock);
+			pthread_mutex_destroy(&input->req->lock);
 			free(input->req);
 		}
 		if (out != AML_SUCCESS)
@@ -117,8 +116,11 @@ int aml_dma_linux_barrier(struct aml_dma_data *dma)
 int aml_dma_linux_request_destroy(struct aml_dma_data *dma,
                                   struct aml_dma_request **req)
 {
+	struct aml_dma_linux_request *r = *(struct aml_dma_linux_request **)req;
+
 	(void)dma;
-	free(*req);
+	pthread_mutex_destroy(&r->lock);
+	free(r);
 	*req = NULL;
 	return AML_SUCCESS;
 }

--- a/src/higher/mapper-replicaset.c
+++ b/src/higher/mapper-replicaset.c
@@ -341,7 +341,7 @@ int aml_mapper_replica_build_start(pthread_t *thread_handle,
 	pthread_cond_wait(&args.initialization_cond, &args.initialization_lock);
 	pthread_mutex_unlock(&args.initialization_lock);
 	// FIXME helgrind complains if this is uncommented -- not sure why?!
-	//pthread_mutex_destroy(&args.initialization_lock);
+	// pthread_mutex_destroy(&args.initialization_lock);
 	pthread_cond_destroy(&args.initialization_cond);
 	*thread_handle = thread;
 	return AML_SUCCESS;

--- a/src/utils/async.c
+++ b/src/utils/async.c
@@ -234,7 +234,7 @@ struct aml_task *aml_queue_sched_wait_any_async(struct aml_sched_data *data)
 	struct aml_task *task = NULL;
 	struct aml_queue_sched *sched = (struct aml_queue_sched *)data;
 	int busy;
-	struct aml_task **busy_cmp[sched->nt];
+	struct aml_task *busy_cmp[sched->nt];
 	memset(busy_cmp, 0, sizeof(busy_cmp));
 
 	// Poll done_q until a task is here.


### PR DESCRIPTION
* Adds a conditional variable in `mapper-replicaset.c` to correctly notify the parent of initialization being complete.
* Makes sure that `aml_queue_len` is always invoked with the right mutex being held.
* `busy_cmp` in `aml_queue_sched_wait_any_async` was using one level of pointers too many (though it probably worked fine).
* Initialization/tear-down of `in_progress_lock` was missing.
* Adds a lock to `struct aml_dma_linux_request` and uses it consistently, especially when accessing `flags` and `output`.
* Unconditionally invokes `aml_sched_wait_task` within `aml_dma_linux_request_wait` -- old code was inherently race'y (though it probably worked fine).