### PR TITLE
[fix] wrong comparison implementation

### DIFF
--- a/src/backend/hwloc.c
+++ b/src/backend/hwloc.c
@@ -99,7 +99,12 @@ int aml_hwloc_distance_lt(const void *a_ptr, const void *b_ptr)
 {
 	struct aml_hwloc_distance *a = (struct aml_hwloc_distance *)a_ptr;
 	struct aml_hwloc_distance *b = (struct aml_hwloc_distance *)b_ptr;
-	return a->distance < b->distance;
+	if (a->distance < b->distance)
+		return -1;
+	else if (a->distance > b->distance)
+		return 1;
+	else
+		return 0;
 }
 
 /**

--- a/src/backend/hwloc.c
+++ b/src/backend/hwloc.c
@@ -17,9 +17,9 @@
 hwloc_topology_t aml_topology;
 hwloc_const_bitmap_t allowed_nodeset;
 
-#define OBJ_DIST(dist, i, j, row_stride, col_stride)                           \
-	(dist)->values[((i)->logical_index + row_stride) * (dist)->nbobjs +    \
-	               col_stride + (j)->logical_index]
+#define OBJ_DIST(dist, i, j, row_offset, col_offset)                           \
+	(dist)->values[((i)->logical_index + row_offset) * (dist)->nbobjs +    \
+	               col_offset + (j)->logical_index]
 
 #define IND_DIST(dist, i, j) (dist)->values[(i) * (dist)->nbobjs + (j)]
 
@@ -351,7 +351,7 @@ static int aml_hwloc_distances_reshape(struct hwloc_distances_s *dist,
 				goto err_with_out;
 			OBJ_DIST(*out, obj0, obj1, 0, nt0) = d0;
 			OBJ_DIST(*out, obj1, obj0, nt0, 0) = d1;
-			obj1 = hwloc_get_next_obj_by_depth(aml_topology, depth0,
+			obj1 = hwloc_get_next_obj_by_depth(aml_topology, depth1,
 			                                   obj1);
 		}
 		obj0 = hwloc_get_next_obj_by_depth(aml_topology, depth0, obj0);

--- a/tests/area/test_hwloc.c
+++ b/tests/area/test_hwloc.c
@@ -210,7 +210,7 @@ void test_preferred()
 	       AML_SUCCESS);
 
 	data = (struct aml_area_hwloc_preferred_data *)area->data;
-	assert(data->numanodes[data->num_nodes - 1] == NUMANODE);
+	assert(data->numanodes[0] == NUMANODE);
 
 	aml_area_hwloc_preferred_destroy(&area);
 }


### PR DESCRIPTION
area_preferred relies on qsort for sorting numa nodes. qsort expects negative,0,positive return values, instead of just 0,1.